### PR TITLE
fix: resync tasks moved from completed

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -953,7 +953,7 @@ export default function App() {
       if (fromIdx < 0) return prev;
       const task = arr[fromIdx];
 
-        const updated: Task = { ...task };
+      const updated: Task = { ...task };
       if (target.type === "day") {
         updated.column = "day";
         updated.columnId = undefined;
@@ -969,6 +969,12 @@ export default function App() {
       }
       // reveal if user manually places it
       updated.hiddenUntilISO = undefined;
+
+      // un-complete if dragging from Completed back onto the board
+      if (updated.completed) {
+        updated.completed = false;
+        updated.completedAt = undefined;
+      }
 
       // remove original
       arr.splice(fromIdx, 1);


### PR DESCRIPTION
## Summary
- ensure tasks dragged from Completed list are marked incomplete and republished

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c06c727f588324b9d4e79dad74fc43