### PR TITLE
feat: enhance wallet send/receive and seed management

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { finalizeEvent, getPublicKey, generateSecretKey, type EventTemplate, nip19 } from "nostr-tools";
-import Wallet from "./wallet";
+import Wallet, { getWalletMnemonic } from "./wallet";
 
 /* ================= Types ================= */
 type Weekday = 0 | 1 | 2 | 3 | 4 | 5 | 6; // 0=Sun
@@ -2382,6 +2382,13 @@ function SettingsModal({
   const [customSk, setCustomSk] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [reloadNeeded, setReloadNeeded] = useState(false);
+  const [seed] = useState(() => getWalletMnemonic());
+  const [seedRevealed, setSeedRevealed] = useState(false);
+
+  function backupSeed() {
+    navigator.clipboard?.writeText(seed);
+    alert("Seed phrase copied to clipboard");
+  }
 
   function backupData() {
     const data = {
@@ -2715,6 +2722,23 @@ function SettingsModal({
                 />
               </div>
             </>
+          )}
+        </section>
+
+        {/* Wallet seed */}
+        <section className="rounded-xl border border-neutral-800 p-3 bg-neutral-900/60">
+          <div className="text-sm font-medium mb-2">Wallet seed</div>
+          <div>
+            <button className="px-3 py-2 rounded-xl bg-neutral-800" onClick={backupSeed}>Backup seed phrase</button>
+            <button
+              className="ml-2 px-3 py-2 rounded-xl bg-neutral-800"
+              onClick={() => setSeedRevealed(r => !r)}
+            >
+              {seedRevealed ? "Hide" : "Show"}
+            </button>
+          </div>
+          {seedRevealed && (
+            <div className="mt-2 text-xs break-all">{seed}</div>
           )}
         </section>
 

--- a/taskify-pwa/src/wallet.tsx
+++ b/taskify-pwa/src/wallet.tsx
@@ -1,45 +1,117 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+// Simple mnemonic generator using color/animal combinations.
+const COLORS = [
+  "red",
+  "blue",
+  "green",
+  "yellow",
+  "purple",
+  "orange",
+  "black",
+  "white",
+  "gray",
+  "brown",
+  "pink",
+  "cyan",
+  "magenta",
+  "lime",
+  "navy",
+  "teal",
+];
+
+const ANIMALS = [
+  "ant",
+  "bear",
+  "cat",
+  "dog",
+  "eel",
+  "fox",
+  "goat",
+  "hen",
+  "ibis",
+  "jay",
+  "koala",
+  "lion",
+  "mole",
+  "newt",
+  "owl",
+  "pig",
+];
+
+function wordFromByte(b: number) {
+  const color = COLORS[b >> 4];
+  const animal = ANIMALS[b & 15];
+  return color + animal;
+}
+
+export function getWalletMnemonic(): string {
+  try {
+    const existing = localStorage.getItem("ecash_wallet_seed");
+    if (existing) return existing;
+  } catch {}
+  const bytes = new Uint8Array(12);
+  crypto.getRandomValues(bytes);
+  const words = Array.from(bytes).map(wordFromByte);
+  const mnemonic = words.join(" ");
+  try {
+    localStorage.setItem("ecash_wallet_seed", mnemonic);
+  } catch {}
+  return mnemonic;
+}
 
 export default function Wallet() {
-  const [seed] = useState(() => {
-    try {
-      const existing = localStorage.getItem("ecash_wallet_seed");
-      if (existing) return existing;
-    } catch {}
-    const arr = new Uint8Array(32);
-    crypto.getRandomValues(arr);
-    const hex = Array.from(arr).map(b => b.toString(16).padStart(2, "0")).join("");
-    try { localStorage.setItem("ecash_wallet_seed", hex); } catch {}
-    return hex;
-  });
-  const [revealed, setRevealed] = useState(false);
+  const [showSend, setShowSend] = useState(false);
+  const [showReceive, setShowReceive] = useState(false);
 
-  const backup = () => {
-    navigator.clipboard?.writeText(seed);
-    alert("Seed phrase copied to clipboard");
-  };
+  // Ensure seed exists
+  useEffect(() => {
+    getWalletMnemonic();
+  }, []);
 
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-medium">Ecash Wallet</h2>
       <div>Balance: 0 sats</div>
-      <div>
-        <button
-          className="px-3 py-2 rounded-xl bg-neutral-800"
-          onClick={backup}
-        >
-          Backup seed phrase
-        </button>
-        <button
-          className="ml-2 px-3 py-2 rounded-xl bg-neutral-800"
-          onClick={() => setRevealed(r => !r)}
-        >
-          {revealed ? "Hide" : "Show"}
-        </button>
-        {revealed && (
-          <div className="mt-2 text-xs break-all">{seed}</div>
-        )}
+      <div className="flex gap-4">
+        <div>
+          <button
+            className="px-3 py-2 rounded-xl bg-neutral-800"
+            onClick={() => setShowSend((s) => !s)}
+          >
+            Send
+          </button>
+          {showSend && (
+            <div className="mt-2 flex gap-2">
+              <button className="px-3 py-2 rounded-xl bg-neutral-800">
+                Ecash
+              </button>
+              <button className="px-3 py-2 rounded-xl bg-neutral-800">
+                Lightning
+              </button>
+            </div>
+          )}
+        </div>
+        <div>
+          <button
+            className="px-3 py-2 rounded-xl bg-neutral-800"
+            onClick={() => setShowReceive((s) => !s)}
+          >
+            Receive
+          </button>
+          {showReceive && (
+            <div className="mt-2 flex gap-2">
+              <button className="px-3 py-2 rounded-xl bg-neutral-800">
+                Ecash
+              </button>
+              <button className="px-3 py-2 rounded-xl bg-neutral-800">
+                Lightning
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- generate and persist wallet seed as 12-word mnemonic
- add send/receive UI with ecash or lightning options
- relocate seed backup and reveal actions to Settings modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1b3b5f1088324b83f2047cc179474