### PR TITLE
feat: add minimal lightning wallet support

### DIFF
--- a/taskify-pwa/src/cashu.ts
+++ b/taskify-pwa/src/cashu.ts
@@ -3,6 +3,12 @@
  * Stores tokens in browser localStorage and supports basic send/receive.
  */
 
+import {
+  createInvoice as lnCreateInvoice,
+  decodeInvoice,
+  payInvoice as lnPayInvoice,
+} from "./lightning";
+
 export type Token = {
   amount: number;
   secret: string;
@@ -66,6 +72,19 @@ export class CashuWallet {
     if (left > 0) return null; // insufficient balance
     saveTokens(remaining);
     return JSON.stringify(toSend[0]); // simplified single-token return
+  }
+
+  /** Create a Lightning invoice for the given amount. */
+  async createLightningInvoice(amount: number): Promise<string> {
+    return lnCreateInvoice(amount);
+  }
+
+  /** Pay a Lightning invoice using wallet balance. */
+  async payLightningInvoice(invoice: string) {
+    const amount = decodeInvoice(invoice);
+    const token = this.send(amount);
+    if (!token) throw new Error("Insufficient balance");
+    await lnPayInvoice(invoice);
   }
 }
 

--- a/taskify-pwa/src/lightning.ts
+++ b/taskify-pwa/src/lightning.ts
@@ -1,0 +1,24 @@
+// Minimal Lightning helpers for demo wallet.
+// These functions simulate creating and paying Lightning invoices.
+
+/** Create a fake Lightning invoice for the specified amount. */
+export async function createInvoice(amount: number): Promise<string> {
+  if (amount <= 0) throw new Error('amount must be positive');
+  const rand = Math.random().toString(36).slice(2);
+  // Simplified bolt11: lnbc{amount}n{random}
+  return `lnbc${amount}n${rand}`;
+}
+
+/** Decode amount from our simplified invoice format. */
+export function decodeInvoice(invoice: string): number {
+  const m = invoice.match(/^lnbc(\d+)n/);
+  if (!m) throw new Error('invalid invoice');
+  return parseInt(m[1], 10);
+}
+
+/** Pay a fake Lightning invoice. */
+export async function payInvoice(invoice: string): Promise<void> {
+  // Validate format then simulate a short delay.
+  decodeInvoice(invoice);
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}

--- a/taskify-pwa/src/wallet.tsx
+++ b/taskify-pwa/src/wallet.tsx
@@ -67,6 +67,10 @@ export default function Wallet() {
   const [sendAmount, setSendAmount] = useState("");
   const [sendToken, setSendToken] = useState("");
   const [receiveToken, setReceiveToken] = useState("");
+  const [lnAmount, setLnAmount] = useState("");
+  const [lnInvoice, setLnInvoice] = useState("");
+  const [payInvoice, setPayInvoice] = useState("");
+  const [payStatus, setPayStatus] = useState("");
 
   // Ensure seed exists
   useEffect(() => {
@@ -90,6 +94,24 @@ export default function Wallet() {
       setReceiveToken("");
       setBalance(wallet.balance);
     } catch {}
+  };
+
+  const handleCreateInvoice = async () => {
+    const amt = parseInt(lnAmount, 10);
+    if (!amt) return;
+    const invoice = await wallet.createLightningInvoice(amt);
+    setLnInvoice(invoice);
+  };
+
+  const handlePayInvoice = async () => {
+    try {
+      await wallet.payLightningInvoice(payInvoice);
+      setBalance(wallet.balance);
+      setPayInvoice("");
+      setPayStatus("Paid");
+    } catch {
+      setPayStatus("Failed");
+    }
   };
 
   return (
@@ -137,6 +159,44 @@ export default function Wallet() {
           >
             Add token
           </button>
+        </div>
+
+        <div>
+          <div className="mb-2 font-medium">Lightning</div>
+          <div className="flex gap-2 mb-2">
+            <input
+              className="px-3 py-2 rounded-xl bg-neutral-900 w-24"
+              value={lnAmount}
+              onChange={(e) => setLnAmount(e.target.value)}
+              placeholder="sats"
+            />
+            <button
+              className="px-3 py-2 rounded-xl bg-neutral-800"
+              onClick={handleCreateInvoice}
+            >
+              Create invoice
+            </button>
+          </div>
+          {lnInvoice && (
+            <textarea
+              className="w-full h-24 p-2 rounded-xl bg-neutral-900 mb-4"
+              readOnly
+              value={lnInvoice}
+            />
+          )}
+          <textarea
+            className="w-full h-24 p-2 rounded-xl bg-neutral-900 mb-2"
+            value={payInvoice}
+            onChange={(e) => setPayInvoice(e.target.value)}
+            placeholder="paste invoice"
+          />
+          <button
+            className="px-3 py-2 rounded-xl bg-neutral-800"
+            onClick={handlePayInvoice}
+          >
+            Pay invoice
+          </button>
+          {payStatus && <div className="mt-2">{payStatus}</div>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add stub lightning helpers to create and pay fake invoices
- expose lightning invoice creation and payment from cashu wallet
- extend wallet UI to generate and pay lightning invoices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1bbc781508324ad1c3d867bd9a739