### PR TITLE
feat: redesign wallet modal with action sheets

### DIFF
--- a/taskify-pwa/src/components/ActionSheet.tsx
+++ b/taskify-pwa/src/components/ActionSheet.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+export function ActionSheet({ open, onClose, title, children }: { open: boolean; onClose: () => void; title?: string; children: React.ReactNode; }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col justify-end bg-black/60">
+      <div className="max-h-[80%] w-full rounded-t-2xl bg-neutral-900 p-4 overflow-y-auto">
+        <div className="flex items-center justify-between mb-3">
+          {title && <div className="font-semibold">{title}</div>}
+          <button className="ml-auto px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" onClick={onClose}>Close</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+

--- a/taskify-pwa/src/components/CashuWalletModal.tsx
+++ b/taskify-pwa/src/components/CashuWalletModal.tsx
@@ -1,33 +1,43 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useCashu } from "../context/CashuContext";
+import { ActionSheet } from "./ActionSheet";
 
 export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { mintUrl, balance, info, createMintInvoice, checkMintQuote, claimMint, receiveToken, createSendToken, payInvoice } = useCashu();
 
-  const [mintAmt, setMintAmt] = useState<string>("");
+  const [showReceiveOptions, setShowReceiveOptions] = useState(false);
+  const [showSendOptions, setShowSendOptions] = useState(false);
+  const [receiveMode, setReceiveMode] = useState<null | "ecash" | "lightning">(null);
+  const [sendMode, setSendMode] = useState<null | "ecash" | "lightning">(null);
+
+  const [mintAmt, setMintAmt] = useState("");
   const [mintQuote, setMintQuote] = useState<{ request: string; quote: string; expiry: number } | null>(null);
   const [mintStatus, setMintStatus] = useState<"idle" | "waiting" | "minted" | "error">("idle");
-  const [mintError, setMintError] = useState<string>("");
+  const [mintError, setMintError] = useState("");
 
-  const [sendAmt, setSendAmt] = useState<string>("");
-  const [sendTokenStr, setSendTokenStr] = useState<string>("");
+  const [sendAmt, setSendAmt] = useState("");
+  const [sendTokenStr, setSendTokenStr] = useState("");
 
-  const [recvTokenStr, setRecvTokenStr] = useState<string>("");
-  const [recvMsg, setRecvMsg] = useState<string>("");
+  const [recvTokenStr, setRecvTokenStr] = useState("");
+  const [recvMsg, setRecvMsg] = useState("");
 
-  const [lnInvoice, setLnInvoice] = useState<string>("");
+  const [lnInvoice, setLnInvoice] = useState("");
   const [lnState, setLnState] = useState<"idle" | "sending" | "done" | "error">("idle");
-  const [lnError, setLnError] = useState<string>("");
+  const [lnError, setLnError] = useState("");
 
-    useEffect(() => {
-      if (!open) {
-        setMintQuote(null);
-        setMintStatus("idle");
+  useEffect(() => {
+    if (!open) {
+      setMintQuote(null);
+      setMintStatus("idle");
       setMintError("");
       setSendTokenStr("");
       setRecvMsg("");
       setLnState("idle");
       setLnError("");
+      setShowReceiveOptions(false);
+      setShowSendOptions(false);
+      setReceiveMode(null);
+      setSendMode(null);
     }
   }, [open]);
 
@@ -37,40 +47,40 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
     return `${parts.join(" ")} • ${mintUrl}`;
   }, [info, mintUrl]);
 
-    async function handleCreateInvoice() {
-      setMintError("");
-      try {
-        const amt = Math.max(0, Math.floor(Number(mintAmt) || 0));
-        if (!amt) throw new Error("Enter amount in sats");
-        const q = await createMintInvoice(amt);
-        setMintQuote(q);
-        setMintStatus("waiting");
-      } catch (e: any) {
-        setMintError(e?.message || String(e));
-      }
+  async function handleCreateInvoice() {
+    setMintError("");
+    try {
+      const amt = Math.max(0, Math.floor(Number(mintAmt) || 0));
+      if (!amt) throw new Error("Enter amount in sats");
+      const q = await createMintInvoice(amt);
+      setMintQuote(q);
+      setMintStatus("waiting");
+    } catch (e: any) {
+      setMintError(e?.message || String(e));
     }
+  }
 
-    useEffect(() => {
-      if (!mintQuote) return;
-      const timer = setInterval(async () => {
-        try {
-          const st = await checkMintQuote(mintQuote.quote);
-          if (st === "PAID") {
-            const amt = Math.max(0, Math.floor(Number(mintAmt) || 0));
-            await claimMint(mintQuote.quote, amt);
-            setMintStatus("minted");
-            setMintQuote(null);
-            setMintAmt("");
-            clearInterval(timer);
-          }
-        } catch (e: any) {
-          setMintError(e?.message || String(e));
-          setMintStatus("error");
+  useEffect(() => {
+    if (!mintQuote) return;
+    const timer = setInterval(async () => {
+      try {
+        const st = await checkMintQuote(mintQuote.quote);
+        if (st === "PAID") {
+          const amt = Math.max(0, Math.floor(Number(mintAmt) || 0));
+          await claimMint(mintQuote.quote, amt);
+          setMintStatus("minted");
+          setMintQuote(null);
+          setMintAmt("");
           clearInterval(timer);
         }
-      }, 3000);
-      return () => clearInterval(timer);
-    }, [mintQuote, mintAmt, checkMintQuote, claimMint]);
+      } catch (e: any) {
+        setMintError(e?.message || String(e));
+        setMintStatus("error");
+        clearInterval(timer);
+      }
+    }, 3000);
+    return () => clearInterval(timer);
+  }, [mintQuote, mintAmt, checkMintQuote, claimMint]);
 
   async function handleCreateSendToken() {
     try {
@@ -115,74 +125,87 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="w-full max-w-2xl rounded-2xl bg-neutral-900 border border-neutral-800 p-4">
-        <div className="flex items-center justify-between mb-3">
-          <div className="font-semibold">Cashu Wallet</div>
-          <button className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" onClick={onClose}>Close</button>
-        </div>
-
-        <div className="text-xs text-neutral-400 mb-3">{headerInfo}</div>
-        <div className="mb-4 text-sm">Balance: <span className="font-mono">{balance}</span> sats</div>
-
-        <div className="grid gap-4">
-          <section className="rounded-xl border border-neutral-800 p-3">
-            <div className="text-sm font-medium mb-2">Top up (Mint eCash)</div>
-            <div className="flex gap-2 mb-2">
-              <input className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={mintAmt} onChange={(e)=>setMintAmt(e.target.value)} />
-              <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleCreateInvoice} disabled={!mintUrl}>Get Invoice</button>
-            </div>
-            {mintQuote && (
-              <div className="text-xs bg-neutral-950 border border-neutral-800 rounded-xl p-2">
-                <div className="mb-1">Invoice:</div>
-                <textarea readOnly className="w-full h-20 bg-transparent outline-none" value={mintQuote.request} />
-                <div className="flex gap-2 mt-2">
-                  <a className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" href={`lightning:${mintQuote.request}`}>Open Wallet</a>
-                  <button className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" onClick={()=>navigator.clipboard.writeText(mintQuote.request)}>Copy</button>
-                </div>
-                <div className="mt-2 text-xs">Status: {mintStatus}</div>
-                {mintError && <div className="mt-1 text-xs text-rose-400">{mintError}</div>}
-              </div>
-            )}
-          </section>
-
-          <section className="rounded-xl border border-neutral-800 p-3">
-            <div className="text-sm font-medium mb-2">Pay Lightning Invoice with eCash</div>
-            <textarea className="w-full h-20 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste BOLT11 invoice" value={lnInvoice} onChange={(e)=>setLnInvoice(e.target.value)} />
-            <div className="mt-2 flex gap-2">
-              <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handlePayInvoice} disabled={!mintUrl || !lnInvoice}>Pay</button>
-              {lnState === "sending" && <div className="text-xs">Paying…</div>}
-              {lnState === "done" && <div className="text-xs text-emerald-400">Paid</div>}
-              {lnState === "error" && <div className="text-xs text-rose-400">{lnError}</div>}
-            </div>
-          </section>
-
-          <section className="rounded-xl border border-neutral-800 p-3">
-            <div className="text-sm font-medium mb-2">Send eCash</div>
-            <div className="flex gap-2 mb-2">
-              <input className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={sendAmt} onChange={(e)=>setSendAmt(e.target.value)} />
-              <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleCreateSendToken} disabled={!mintUrl}>Create Token</button>
-            </div>
-            {sendTokenStr && (
-              <div className="text-xs bg-neutral-950 border border-neutral-800 rounded-xl p-2">
-                <textarea readOnly className="w-full h-24 bg-transparent outline-none" value={sendTokenStr} />
-                <div className="mt-2">
-                  <button className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" onClick={()=>navigator.clipboard.writeText(sendTokenStr)}>Copy</button>
-                </div>
-              </div>
-            )}
-          </section>
-
-          <section className="rounded-xl border border-neutral-800 p-3">
-            <div className="text-sm font-medium mb-2">Receive eCash</div>
-            <textarea className="w-full h-24 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste Cashu token (cashuA...)" value={recvTokenStr} onChange={(e)=>setRecvTokenStr(e.target.value)} />
-            <div className="mt-2 flex gap-2 items-center">
-              <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleReceive} disabled={!mintUrl || !recvTokenStr}>Redeem</button>
-              {recvMsg && <div className="text-xs">{recvMsg}</div>}
-            </div>
-          </section>
-        </div>
+    <div className="fixed inset-0 z-40 flex flex-col bg-neutral-950 text-white">
+      <div className="flex items-center justify-between p-4">
+        <button className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" onClick={onClose}>Close</button>
+        <div className="text-sm font-medium">{info?.unit?.toUpperCase() || "SAT"}</div>
       </div>
+      <div className="flex-1 flex flex-col items-center justify-center">
+        <div className="text-5xl font-semibold mb-1">{balance} sat</div>
+        <div className="text-neutral-400 text-xs">{headerInfo}</div>
+      </div>
+      <div className="p-4 flex gap-3">
+        <button className="flex-1 py-3 rounded-full bg-neutral-100 text-neutral-900 font-semibold" onClick={()=>setShowReceiveOptions(true)}>RECEIVE</button>
+        <button className="flex-1 py-3 rounded-full bg-neutral-100 text-neutral-900 font-semibold" onClick={()=>setShowSendOptions(true)}>SEND</button>
+      </div>
+
+      {/* Receive options */}
+      <ActionSheet open={showReceiveOptions && receiveMode === null} onClose={()=>setShowReceiveOptions(false)} title="Receive">
+        <div className="grid gap-2">
+          <button className="w-full px-4 py-3 rounded-xl bg-neutral-800 hover:bg-neutral-700 text-left" onClick={()=>setReceiveMode("ecash")}>ECASH</button>
+          <button className="w-full px-4 py-3 rounded-xl bg-neutral-800 hover:bg-neutral-700 text-left" onClick={()=>setReceiveMode("lightning")}>LIGHTNING</button>
+        </div>
+      </ActionSheet>
+
+      <ActionSheet open={receiveMode === "ecash"} onClose={()=>{setReceiveMode(null); setShowReceiveOptions(false);}} title="Receive eCash">
+        <textarea className="w-full h-24 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste Cashu token (cashuA...)" value={recvTokenStr} onChange={(e)=>setRecvTokenStr(e.target.value)} />
+        <div className="mt-2 flex gap-2 items-center">
+          <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleReceive} disabled={!mintUrl || !recvTokenStr}>Redeem</button>
+          {recvMsg && <div className="text-xs">{recvMsg}</div>}
+        </div>
+      </ActionSheet>
+
+      <ActionSheet open={receiveMode === "lightning"} onClose={()=>{setReceiveMode(null); setShowReceiveOptions(false);}} title="Mint via Lightning">
+        <div className="flex gap-2 mb-2">
+          <input className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={mintAmt} onChange={(e)=>setMintAmt(e.target.value)} />
+          <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleCreateInvoice} disabled={!mintUrl}>Get Invoice</button>
+        </div>
+        {mintQuote && (
+          <div className="text-xs bg-neutral-950 border border-neutral-800 rounded-xl p-2">
+            <div className="mb-1">Invoice:</div>
+            <textarea readOnly className="w-full h-20 bg-transparent outline-none" value={mintQuote.request} />
+            <div className="flex gap-2 mt-2">
+              <a className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" href={`lightning:${mintQuote.request}`}>Open Wallet</a>
+              <button className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" onClick={()=>navigator.clipboard.writeText(mintQuote.request)}>Copy</button>
+            </div>
+            <div className="mt-2 text-xs">Status: {mintStatus}</div>
+            {mintError && <div className="mt-1 text-xs text-rose-400">{mintError}</div>}
+          </div>
+        )}
+      </ActionSheet>
+
+      {/* Send options */}
+      <ActionSheet open={showSendOptions && sendMode === null} onClose={()=>setShowSendOptions(false)} title="Send">
+        <div className="grid gap-2">
+          <button className="w-full px-4 py-3 rounded-xl bg-neutral-800 hover:bg-neutral-700 text-left" onClick={()=>setSendMode("ecash")}>ECASH</button>
+          <button className="w-full px-4 py-3 rounded-xl bg-neutral-800 hover:bg-neutral-700 text-left" onClick={()=>setSendMode("lightning")}>LIGHTNING</button>
+        </div>
+      </ActionSheet>
+
+      <ActionSheet open={sendMode === "ecash"} onClose={()=>{setSendMode(null); setShowSendOptions(false);}} title="Send eCash">
+        <div className="flex gap-2 mb-2">
+          <input className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={sendAmt} onChange={(e)=>setSendAmt(e.target.value)} />
+          <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleCreateSendToken} disabled={!mintUrl}>Create Token</button>
+        </div>
+        {sendTokenStr && (
+          <div className="text-xs bg-neutral-950 border border-neutral-800 rounded-xl p-2">
+            <textarea readOnly className="w-full h-24 bg-transparent outline-none" value={sendTokenStr} />
+            <div className="mt-2">
+              <button className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" onClick={()=>navigator.clipboard.writeText(sendTokenStr)}>Copy</button>
+            </div>
+          </div>
+        )}
+      </ActionSheet>
+
+      <ActionSheet open={sendMode === "lightning"} onClose={()=>{setSendMode(null); setShowSendOptions(false);}} title="Pay Lightning Invoice">
+        <textarea className="w-full h-20 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste BOLT11 invoice" value={lnInvoice} onChange={(e)=>setLnInvoice(e.target.value)} />
+        <div className="mt-2 flex gap-2">
+          <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handlePayInvoice} disabled={!mintUrl || !lnInvoice}>Pay</button>
+          {lnState === "sending" && <div className="text-xs">Paying…</div>}
+          {lnState === "done" && <div className="text-xs text-emerald-400">Paid</div>}
+          {lnState === "error" && <div className="text-xs text-rose-400">{lnError}</div>}
+        </div>
+      </ActionSheet>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- redesign Cashu wallet modal with centered balance and send/receive flows
- add reusable ActionSheet component for bottom sheet interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d9e99ee48324851f59b45ae56418