### PR TITLE
Support OS dynamic type for font scaling

### DIFF
--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -19,8 +19,9 @@
 
 /* Ensure app fills screen */
 :root {
-  /* Default base font size; overridden by app setting */
-  --app-font-size: 18px;
+  /* Use the OS preferred reading size (Dynamic Type on iOS) */
+  font: -apple-system-body;
+  -webkit-text-size-adjust: 100%;
 }
 html, body, #root {
   height: 100%;
@@ -28,8 +29,6 @@ html, body, #root {
   color: #f5f5f5;            /* fallback text color */
   margin: 0;
   padding: 0;
-  /* Scale the entire UI via rems */
-  font-size: var(--app-font-size);
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";


### PR DESCRIPTION
## Summary
- Use `-apple-system-body` and remove hardcoded root font sizing so text respects the OS preferred reading size
- Allow font size setting to fall back to the system default and add a **System** option in settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6cfaca2088324962418dee4755724