### PR TITLE
fix: preserve card width at large text sizes

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2376,7 +2376,7 @@ function DroppableColumn({
   return (
     <div
       ref={ref}
-      className="rounded-2xl bg-neutral-900/60 border border-neutral-800 p-3 min-h-[18rem] w-[18rem] shrink-0"
+      className="rounded-2xl bg-neutral-900/60 border border-neutral-800 p-3 min-h-[288px] w-[288px] shrink-0"
       // No touchAction lock so horizontal scrolling stays fluid
       {...props}
     >


### PR DESCRIPTION
## Summary
- use pixel-based width and height for board columns so cards maintain layout when system text sizes change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6d86a38448324ae0897be40b571d8