### PR TITLE
Display settings and refresh buttons side by side

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1708,7 +1708,7 @@ export default function App() {
                 </div>
               )}
             </div>
-            <div className="grid gap-2">
+            <div className="flex gap-2">
               {currentBoard?.nostr?.boardId && (
                 <button
                   className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"


### PR DESCRIPTION
## Summary
- Show shared board refresh and settings buttons inline instead of stacked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e41994e883249363a1d3a29253ac