### PR TITLE
Fix iOS layout for add bar and safe areas

### DIFF
--- a/taskify-pwa/index.html
+++ b/taskify-pwa/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Taskify</title>
     <meta name="apple-mobile-web-app-title" content="Taskify" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1771,59 +1771,61 @@ export default function App() {
               </div>
             )}
 
-            {/* Column picker (adapts to board) */}
-            {currentBoard.kind === "week" ? (
+            {/* Column picker, recurrence and add button */}
+            <div className="w-full flex gap-2 items-center">
+              {currentBoard.kind === "week" ? (
+                <select
+                  value={dayChoice === "bounties" ? "bounties" : String(dayChoice)}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    setDayChoice(v === "bounties" ? "bounties" : (Number(v) as Weekday));
+                    setScheduleDate("");
+                  }}
+                  className="shrink-0 w-28 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 truncate"
+                >
+                  {WD_SHORT.map((d,i)=>(<option key={i} value={i}>{d}</option>))}
+                  <option value="bounties">Bounties</option>
+                </select>
+              ) : (
+                <select
+                  value={String(dayChoice)}
+                  onChange={(e)=>setDayChoice(e.target.value)}
+                  className="shrink-0 w-28 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 truncate"
+                >
+                  {listColumns.map(c => (<option key={c.id} value={c.id}>{c.name}</option>))}
+                </select>
+              )}
+
+              {/* Recurrence select with Custom… */}
               <select
-                value={dayChoice === "bounties" ? "bounties" : String(dayChoice)}
+                value={quickRule}
                 onChange={(e) => {
-                  const v = e.target.value;
-                  setDayChoice(v === "bounties" ? "bounties" : (Number(v) as Weekday));
-                  setScheduleDate("");
+                  const v = e.target.value as typeof quickRule;
+                  setQuickRule(v);
+                  if (v === "custom") setShowAddAdvanced(true);
                 }}
-                className="min-w-0 w-32 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 truncate"
+                className="flex-1 min-w-0 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+                title="Recurrence"
               >
-                {WD_SHORT.map((d,i)=>(<option key={i} value={i}>{d}</option>))}
-                <option value="bounties">Bounties</option>
+                <option value="none">No recurrence</option>
+                <option value="daily">Daily</option>
+                <option value="weeklyMonFri">Mon–Fri</option>
+                <option value="weeklyWeekends">Weekends</option>
+                <option value="every2d">Every 2 days</option>
+                <option value="custom">Custom…</option>
               </select>
-            ) : (
-              <select
-                value={String(dayChoice)}
-                onChange={(e)=>setDayChoice(e.target.value)}
-                className="min-w-0 w-32 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 truncate"
+
+              {quickRule === "custom" && addCustomRule.type !== "none" && (
+                <span className="flex-shrink-0 text-xs text-neutral-400">({labelOf(addCustomRule)})</span>
+              )}
+
+              <button
+                onClick={() => addTask()}
+                className="shrink-0 px-4 py-2 rounded-2xl bg-emerald-600 hover:bg-emerald-500 font-medium"
               >
-                {listColumns.map(c => (<option key={c.id} value={c.id}>{c.name}</option>))}
-              </select>
-            )}
-
-            {/* Recurrence select with Custom… */}
-            <select
-              value={quickRule}
-              onChange={(e) => {
-                const v = e.target.value as typeof quickRule;
-                setQuickRule(v);
-                if (v === "custom") setShowAddAdvanced(true);
-              }}
-              className="min-w-0 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
-              title="Recurrence"
-            >
-              <option value="none">No recurrence</option>
-              <option value="daily">Daily</option>
-              <option value="weeklyMonFri">Mon–Fri</option>
-              <option value="weeklyWeekends">Weekends</option>
-              <option value="every2d">Every 2 days</option>
-              <option value="custom">Custom…</option>
-            </select>
-
-            {quickRule === "custom" && addCustomRule.type !== "none" && (
-              <span className="text-xs text-neutral-400">({labelOf(addCustomRule)})</span>
-            )}
-
-            <button
-              onClick={() => addTask()}
-              className="px-4 py-2 rounded-2xl bg-emerald-600 hover:bg-emerald-500 font-medium"
-            >
-              Add
-            </button>
+                Add
+              </button>
+            </div>
           </div>
         )}
 

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -35,6 +35,14 @@ html, body, #root {
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
+/* Respect iOS safe areas when running as a standalone app */
+body {
+  padding-top: env(safe-area-inset-top);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
 /* Smooth transitions for interactive elements */
 button, input, select, textarea {
   transition: background-color 0.2s ease, color 0.2s ease,


### PR DESCRIPTION
## Summary
- Allow PWA to use full screen with safe-area insets on iOS
- Tidy add task bar so column selector, recurrence and add button share one row

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c707aa2b30832495090ee0dcfdc2fa