### PR TITLE
Remove horizontal padding and fix Completed tab cutoff

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1652,7 +1652,7 @@ export default function App() {
   const scrollerRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div className="min-h-screen bg-neutral-950 text-neutral-100 p-4">
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 py-4">
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <header className="mb-4">
@@ -1667,7 +1667,7 @@ export default function App() {
             </button>
           </div>
           <div ref={confettiRef} className="relative h-0 w-full" />
-          <div className="flex items-center gap-3 w-full overflow-x-auto">
+          <div className="flex items-center gap-3 w-full overflow-x-auto pr-4">
             {/* Board switcher and refresh */}
             <div className="flex items-center gap-2">
               <div


### PR DESCRIPTION
## Summary
- Eliminate horizontal padding so layout reaches screen edges
- Add right padding to header scroller to keep Completed tab fully visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c714d723e88324a46e5d5a377a5fa8