### PR TITLE
Fix board selector drag-open

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1697,16 +1697,23 @@ export default function App() {
             <div className="flex items-center gap-2">
               <div
                 className="relative"
-                onDragEnter={e => {
+                onDragOver={e => {
                   if (!draggingTaskId) return;
                   e.preventDefault();
-                  if (boardDropTimer.current) window.clearTimeout(boardDropTimer.current);
-                  boardDropTimer.current = window.setTimeout(() => setBoardDropOpen(true), 500);
+                  if (!boardDropOpen && !boardDropTimer.current) {
+                    boardDropTimer.current = window.setTimeout(() => {
+                      setBoardDropOpen(true);
+                      boardDropTimer.current = undefined;
+                    }, 500);
+                  }
                 }}
-                onDragOver={e => { if (draggingTaskId) e.preventDefault(); }}
                 onDragLeave={() => {
                   if (!draggingTaskId) return;
-                  if (boardDropTimer.current) window.clearTimeout(boardDropTimer.current);
+                  if (boardDropTimer.current) {
+                    window.clearTimeout(boardDropTimer.current);
+                    boardDropTimer.current = undefined;
+                  }
+                  setBoardDropOpen(false);
                 }}
               >
                 <select


### PR DESCRIPTION
## Summary
- ensure board switcher reveals board list when dragging a task over it
- clear pending open timer and close board list when drag leaves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71f78f97483248bb5db17e0b92c89