### PR TITLE
fix: keep board list visible while dragging tasks

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { finalizeEvent, getPublicKey, generateSecretKey, type EventTemplate, nip19, nip04 } from "nostr-tools";
 import { CashuWalletModal } from "./components/CashuWalletModal";
 import { useCashu } from "./context/CashuContext";
@@ -705,14 +706,34 @@ export default function App() {
   const [trashHover, setTrashHover] = useState(false);
   const [upcomingHover, setUpcomingHover] = useState(false);
   const [boardDropOpen, setBoardDropOpen] = useState(false);
+  const [boardDropPos, setBoardDropPos] = useState<{ top: number; left: number } | null>(null);
   const boardDropTimer = useRef<number>();
+  const boardDropCloseTimer = useRef<number>();
+
+  function scheduleBoardDropClose() {
+    if (boardDropCloseTimer.current) window.clearTimeout(boardDropCloseTimer.current);
+    boardDropCloseTimer.current = window.setTimeout(() => {
+      setBoardDropOpen(false);
+      setBoardDropPos(null);
+      boardDropCloseTimer.current = undefined;
+    }, 100);
+  }
+
+  function cancelBoardDropClose() {
+    if (boardDropCloseTimer.current) {
+      window.clearTimeout(boardDropCloseTimer.current);
+      boardDropCloseTimer.current = undefined;
+    }
+  }
 
   function handleDragEnd() {
     setDraggingTaskId(null);
     setTrashHover(false);
     setUpcomingHover(false);
     setBoardDropOpen(false);
+    setBoardDropPos(null);
     if (boardDropTimer.current) window.clearTimeout(boardDropTimer.current);
+    if (boardDropCloseTimer.current) window.clearTimeout(boardDropCloseTimer.current);
   }
 
   // upcoming drawer (out-of-the-way FAB)
@@ -1703,38 +1724,25 @@ export default function App() {
                 onDragOver={e => {
                   if (!draggingTaskId) return;
                   e.preventDefault();
+                  cancelBoardDropClose();
                   if (!boardDropOpen && !boardDropTimer.current) {
                     boardDropTimer.current = window.setTimeout(() => {
+                      const rect = boardDropContainerRef.current?.getBoundingClientRect();
+                      if (rect) {
+                        setBoardDropPos({ top: rect.top, left: rect.right });
+                      }
                       setBoardDropOpen(true);
                       boardDropTimer.current = undefined;
                     }, 500);
                   }
                 }}
-                onDragLeave={e => {
+                onDragLeave={() => {
                   if (!draggingTaskId) return;
                   if (boardDropTimer.current) {
                     window.clearTimeout(boardDropTimer.current);
                     boardDropTimer.current = undefined;
                   }
-                  const listRect = boardDropListRef.current?.getBoundingClientRect();
-                  const containerRect = boardDropContainerRef.current?.getBoundingClientRect();
-                  if (boardDropOpen && (listRect || containerRect)) {
-                    const { clientX: x, clientY: y } = e;
-                    const withinContainer =
-                      !!containerRect &&
-                      x >= containerRect.left &&
-                      x <= containerRect.right &&
-                      y >= containerRect.top &&
-                      y <= containerRect.bottom;
-                    const withinList =
-                      !!listRect &&
-                      x >= listRect.left &&
-                      x <= listRect.right &&
-                      y >= listRect.top &&
-                      y <= listRect.bottom;
-                    if (withinContainer || withinList) return;
-                  }
-                  setBoardDropOpen(false);
+                  scheduleBoardDropClose();
                 }}
               >
                 <select
@@ -1751,44 +1759,40 @@ export default function App() {
                     boards.map(b => <option key={b.id} value={b.id}>{b.name}</option>)
                   )}
                 </select>
-                {boardDropOpen && (
-                  <div
-                    ref={boardDropListRef}
-                    className="absolute left-full top-0 w-48 rounded-xl border border-neutral-800 bg-neutral-900 z-50"
-                    onDragLeave={e => {
-                      if (!draggingTaskId) return;
-                      const containerRect = boardDropContainerRef.current?.getBoundingClientRect();
-                      if (containerRect) {
-                        const { clientX: x, clientY: y } = e;
-                        if (
-                          x >= containerRect.left &&
-                          x <= containerRect.right &&
-                          y >= containerRect.top &&
-                          y <= containerRect.bottom
-                        ) {
-                          return;
-                        }
-                      }
-                      setBoardDropOpen(false);
-                    }}
-                  >
-                    {boards.map(b => (
-                      <div
-                        key={b.id}
-                        className="px-3 py-2 hover:bg-neutral-800"
-                        onDragOver={e => { if (draggingTaskId) e.preventDefault(); }}
-                        onDrop={e => {
-                          if (!draggingTaskId) return;
-                          e.preventDefault();
-                          moveTaskToBoard(draggingTaskId, b.id);
-                          handleDragEnd();
-                        }}
-                      >
-                        {b.name}
-                      </div>
-                    ))}
-                  </div>
-                )}
+                {boardDropOpen && boardDropPos &&
+                  createPortal(
+                    <div
+                      ref={boardDropListRef}
+                      className="fixed w-48 rounded-xl border border-neutral-800 bg-neutral-900 z-50"
+                      style={{ top: boardDropPos.top, left: boardDropPos.left }}
+                      onDragOver={e => {
+                        if (!draggingTaskId) return;
+                        e.preventDefault();
+                        cancelBoardDropClose();
+                      }}
+                      onDragLeave={() => {
+                        if (!draggingTaskId) return;
+                        scheduleBoardDropClose();
+                      }}
+                    >
+                      {boards.map(b => (
+                        <div
+                          key={b.id}
+                          className="px-3 py-2 hover:bg-neutral-800"
+                          onDragOver={e => { if (draggingTaskId) e.preventDefault(); }}
+                          onDrop={e => {
+                            if (!draggingTaskId) return;
+                            e.preventDefault();
+                            moveTaskToBoard(draggingTaskId, b.id);
+                            handleDragEnd();
+                          }}
+                        >
+                          {b.name}
+                        </div>
+                      ))}
+                    </div>,
+                    document.body
+                  )}
               </div>
             </div>
             <div className="ml-auto flex-shrink-0">


### PR DESCRIPTION
## Summary
- ensure board list dropdown is rendered via portal to avoid being clipped
- track dropdown position so it appears next to the board selector
- delay closing the board dropdown while dragging to prevent it from disappearing early

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c724b582e48324bea5a3caa3dd6391