### PR TITLE
Reduce vertical padding for buttons, tasks, and inputs

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2325,7 +2325,7 @@ export default function App() {
             ) : (
               <ul className="space-y-2">
                 {completed.map((t) => (
-                  <li key={t.id} className="px-3 py-0.5 rounded-xl bg-neutral-800 border border-neutral-700">
+                  <li key={t.id} className="task px-3 rounded-xl bg-neutral-800 border border-neutral-700">
                     <div className="flex items-start gap-2">
                       <div className="flex-1">
                       <div className="text-sm font-medium leading-[1.15]">
@@ -2400,7 +2400,7 @@ export default function App() {
           ) : (
             <ul className="space-y-2">
               {upcoming.map((t) => (
-                <li key={t.id} className="px-3 py-0.5 rounded-xl bg-neutral-900 border border-neutral-800">
+                <li key={t.id} className="task px-3 rounded-xl bg-neutral-900 border border-neutral-800">
                   <div className="flex items-start gap-2">
                     <div className="flex-1">
                       <div className="text-sm font-medium leading-[1.15]">{renderTitleWithLink(t.title, t.note)}</div>
@@ -2825,7 +2825,7 @@ function Card({
   return (
     <div
       ref={cardRef}
-      className="group relative px-2 py-0.5 rounded-xl bg-neutral-800 border border-neutral-700 select-none"
+      className="task group relative px-2 rounded-xl bg-neutral-800 border border-neutral-700 select-none"
       // Allow horizontal swiping across columns on mobile
       style={{ touchAction: "auto" }}
       draggable

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -49,11 +49,19 @@ button, input, select, textarea {
               border-color 0.2s ease, opacity 0.2s ease;
 }
 
-/* Compact spacing for buttons and selects */
+/* Compact spacing for buttons, tasks, and textboxes */
 @layer base {
   button,
   select {
     padding: 0.125rem 0.5rem !important;
+  }
+
+  /* Reduce vertical padding for inputs and textareas */
+  input,
+  textarea,
+  .task {
+    padding-top: 0.125rem !important;
+    padding-bottom: 0.125rem !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- apply shared `.task` class and global rules to ensure tasks have 0.125rem vertical padding
- trim top and bottom padding for text inputs and textareas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f9131a38832482c3832e3e7c35df