### PR TITLE
Expand inline view columns to use full screen height

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2750,7 +2750,7 @@ function DroppableColumn({
   return (
     <div
       ref={ref}
-      className={`rounded-2xl bg-neutral-900/60 border border-neutral-800 p-3 w-[288px] shrink-0 ${scrollable ? 'h-96 flex flex-col' : 'min-h-[288px]'}`}
+      className={`rounded-2xl bg-neutral-900/60 border border-neutral-800 p-3 w-[288px] shrink-0 ${scrollable ? 'h-[calc(100vh-9rem)] flex flex-col' : 'min-h-[288px]'}`}
       // No touchAction lock so horizontal scrolling stays fluid
       {...props}
     >


### PR DESCRIPTION
## Summary
- let inline view columns stretch to the bottom of the screen
- adjust height calculation so inline columns don't extend past the viewport

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c805afd7bc8324b73ccf90d2c9bccd