### PR TITLE
Adjust light theme button colors and wallet icon

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1979,7 +1979,7 @@ export default function App() {
                 onClick={() => setShowWallet(true)}
                 title="Wallet"
               >
-                💰
+                <span className="wallet-icon">💰</span>
               </button>
               {/* Settings */}
               <button

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -104,3 +104,16 @@ button, input, select, textarea {
 ::-webkit-scrollbar-track {
   background: #18181b; /* neutral-900 */
 }
+/* Light theme color adjustments */
+html.light button[class*="bg-emerald"] {
+  filter: brightness(1.15);
+}
+
+html.light button[class*="bg-rose"] {
+  filter: brightness(0.9);
+}
+
+/* Uninvert wallet emoji */
+html.light .wallet-icon {
+  filter: invert(1) hue-rotate(180deg);
+}


### PR DESCRIPTION
## Summary
- lighten green buttons and deepen red buttons in light theme
- fix wallet emoji inversion so dollar sign renders correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c834353dd48324a78d78ab7c08c02f