### PR TITLE
Simplify new task fly-in animation

### DIFF
--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -117,3 +117,83 @@ html.light button[class*="bg-rose"] {
 html.light .wallet-icon {
   filter: invert(1) hue-rotate(180deg);
 }
+
+@keyframes flyPulseBoard {
+  0% {
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0);
+  }
+  45% {
+    box-shadow: 0 0 0 8px rgba(16, 185, 129, 0.28);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0);
+  }
+}
+
+.fly-target-pulse-board {
+  animation: flyPulseBoard 620ms ease;
+}
+
+@keyframes flyPulseUpcoming {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+  }
+  45% {
+    box-shadow: 0 0 0 8px rgba(59, 130, 246, 0.28);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+  }
+}
+
+.fly-target-pulse-upcoming {
+  animation: flyPulseUpcoming 620ms ease;
+}
+
+.fly-task-card {
+  position: fixed;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.9rem;
+  background: rgba(38, 38, 38, 0.96);
+  border: 1px solid rgba(63, 63, 70, 0.88);
+  color: rgba(244, 244, 245, 0.95);
+  min-width: 8.5rem;
+  max-width: 18rem;
+  box-sizing: border-box;
+  overflow: hidden;
+  z-index: 1000;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  transition:
+    left 560ms cubic-bezier(.16,.72,.3,1),
+    top 560ms cubic-bezier(.16,.72,.3,1),
+    transform 560ms cubic-bezier(.16,.72,.3,1),
+    opacity 220ms ease 420ms;
+  will-change: transform, left, top, opacity;
+}
+
+.fly-task-card__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.fly-task-card__title {
+  font-weight: 600;
+  font-size: 0.78rem;
+  line-height: 1.25;
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+


### PR DESCRIPTION
## Summary
- start fly-in animations for newly created tasks from the add-task text field
- style the fly-in element as a compact task card while preserving destination highlight pulses
- show only the new task title in the fly-in card without checkmarks or destination metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c864637c1883249e2bd9d5c617f443