### PR TITLE
Set dark theme as default

### DIFF
--- a/taskify-pwa/index.html
+++ b/taskify-pwa/index.html
@@ -1,14 +1,14 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Taskify</title>
     <meta name="apple-mobile-web-app-title" content="Taskify" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#fafafa" />
+    <meta name="theme-color" content="#0a0a0a" />
   </head>
   <body>
     <div id="root"></div>

--- a/taskify-pwa/public/manifest.webmanifest
+++ b/taskify-pwa/public/manifest.webmanifest
@@ -3,8 +3,8 @@
   "short_name": "Taskify",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#fafafa",
-  "theme_color": "#fafafa",
+  "background_color": "#0a0a0a",
+  "theme_color": "#0a0a0a",
   "icons": [
     { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" }

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -469,7 +469,7 @@ function useSettings() {
         inlineAdd: false,
         ...parsed,
         baseFontSize,
-        theme: typeof parsed.theme === "string" ? parsed.theme : "system",
+        theme: typeof parsed.theme === "string" ? parsed.theme : "dark",
       };
     } catch {
       return {
@@ -480,7 +480,7 @@ function useSettings() {
         showFullWeekRecurring: false,
         inlineAdd: false,
         baseFontSize: null,
-        theme: "system",
+        theme: "dark",
       };
     }
   });


### PR DESCRIPTION
## Summary
- set the default settings theme to dark when no preference is stored
- apply dark defaults to the base HTML theme metadata and iOS status bar style
- update the web manifest colors to match the dark default theme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c86ee6f7b0832485a13f97652b01a0