### PR TITLE
Set inline add and top task placement as defaults

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -486,11 +486,11 @@ function useSettings() {
       }
       return {
         weekStart: 0,
-        newTaskPosition: "bottom",
+        newTaskPosition: "top",
         streaksEnabled: true,
         completedTab: true,
         showFullWeekRecurring: false,
-        inlineAdd: false,
+        inlineAdd: true,
         ...parsed,
         baseFontSize,
         theme: typeof parsed.theme === "string" ? parsed.theme : "dark",
@@ -499,11 +499,11 @@ function useSettings() {
     } catch {
       return {
         weekStart: 0,
-        newTaskPosition: "bottom",
+        newTaskPosition: "top",
         streaksEnabled: true,
         completedTab: true,
         showFullWeekRecurring: false,
-        inlineAdd: false,
+        inlineAdd: true,
         baseFontSize: null,
         theme: "dark",
         startBoardByDay: {},


### PR DESCRIPTION
## Summary
- default settings now enable inline add boxes when no preference is stored
- ensure newly created tasks go to the top of their board by default

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9c0a06fa48324b0ec7aeb4ee452aa