### PR TITLE
Refine settings layout with compact advanced controls

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2408,7 +2408,7 @@ export default function App() {
               {/* Refresh (if shared) */}
               {currentBoard?.nostr?.boardId && (
                 <button
-                  className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+                  className="ios-icon-button bg-neutral-900 border border-neutral-800 hover:bg-neutral-800"
                   onClick={() => setNostrRefresh(n => n + 1)}
                   title="Refresh shared board"
                 >
@@ -2429,22 +2429,14 @@ export default function App() {
                   </svg>
                 </button>
               )}
-              {/* Wallet */}
-              <button
-                ref={walletButtonRef}
-                className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
-                onClick={() => setShowWallet(true)}
-                title="Wallet"
-              >
-                <span className="wallet-icon">💰</span>
-              </button>
               {/* Settings */}
               <button
-                className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+                className="ios-icon-button bg-neutral-900 border border-neutral-800 hover:bg-neutral-800"
                 onClick={() => setShowSettings(true)}
                 title="Settings"
               >
-                ⚙️
+                <span aria-hidden className="text-base leading-none">⚙️</span>
+                <span className="sr-only">Settings</span>
               </button>
             </div>
           </div>
@@ -2479,13 +2471,13 @@ export default function App() {
                   scheduleBoardDropClose();
                 }}
               >
-                <select
-                  ref={boardSelectorRef}
-                  value={currentBoardId}
-                  onChange={handleBoardSelect}
-                  className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
-                  title="Boards"
-                >
+              <select
+                ref={boardSelectorRef}
+                value={currentBoardId}
+                onChange={handleBoardSelect}
+                className="ios-field"
+                title="Boards"
+              >
                   {visibleBoards.length === 0 ? (
                     <option value="">No boards</option>
                   ) : (
@@ -2532,15 +2524,46 @@ export default function App() {
                   )}
               </div>
             </div>
-            <div className="ml-auto flex-shrink-0">
+            <div className="ml-auto flex items-center gap-3 flex-shrink-0">
+              {/* Wallet */}
+              <button
+                ref={walletButtonRef}
+                className="ios-icon-button bg-neutral-900 border border-neutral-800 hover:bg-neutral-800"
+                onClick={() => setShowWallet(true)}
+                title="Wallet"
+              >
+                <span aria-hidden className="wallet-icon leading-none">💰</span>
+                <span className="sr-only">Wallet</span>
+              </button>
               {settings.completedTab ? (
-                <div className="bg-neutral-900 border border-neutral-800 rounded-xl overflow-hidden flex">
-                  <button className={`px-3 py-2 flex-1 ${view==="board" ? "bg-neutral-800":""}`} onClick={()=>setView("board")}>Board</button>
-                  <button ref={completedTabRef} className={`px-3 py-2 flex-1 ${view==="completed" ? "bg-neutral-800":""}`} onClick={()=>setView("completed")}>Completed</button>
-                </div>
+                <button
+                  ref={completedTabRef}
+                  className={`ios-icon-button border focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 ${
+                    view === "completed"
+                      ? "bg-emerald-600 border-emerald-500 hover:bg-emerald-500"
+                      : "bg-neutral-900 border-neutral-800 hover:bg-neutral-800"
+                  }`}
+                  onClick={() => setView((prev) => (prev === "completed" ? "board" : "completed"))}
+                  aria-pressed={view === "completed"}
+                  aria-label={view === "completed" ? "Show board" : "Show completed tasks"}
+                  title={view === "completed" ? "Show board" : "Show completed tasks"}
+                >
+                  <svg
+                    aria-hidden
+                    viewBox="0 0 20 20"
+                    className="h-5 w-5 text-white"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="4 11 8 15 16 6" />
+                  </svg>
+                </button>
               ) : (
                 <button
-                  className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 disabled:opacity-50"
+                  className="ios-pill-button bg-neutral-900 border border-neutral-800 hover:bg-neutral-800 disabled:opacity-50"
                   onClick={clearCompleted}
                   disabled={completed.length === 0}
                 >
@@ -2569,12 +2592,12 @@ export default function App() {
                 }
               }}
               placeholder="New task…"
-              className="flex-1 min-w-0 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 outline-none"
+              className="ios-field flex-1 min-w-0"
             />
             <button
               ref={addButtonRef}
               onClick={() => addTask()}
-              className="shrink-0 px-4 py-2 rounded-2xl bg-emerald-600 hover:bg-emerald-500 font-medium"
+              className="ios-pill-button shrink-0 bg-emerald-600 hover:bg-emerald-500 text-white"
             >
               Add
             </button>
@@ -2596,7 +2619,7 @@ export default function App() {
                     setDayChoice(v === "bounties" ? "bounties" : (Number(v) as Weekday));
                     setScheduleDate("");
                   }}
-                  className="flex-1 min-w-0 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 truncate"
+                  className="ios-field flex-1 min-w-0 truncate"
                 >
                   {WD_SHORT.map((d,i)=>(<option key={i} value={i}>{d}</option>))}
                   <option value="bounties">Bounties</option>
@@ -2605,7 +2628,7 @@ export default function App() {
                 <select
                   value={String(dayChoice)}
                   onChange={(e)=>setDayChoice(e.target.value)}
-                  className="flex-1 min-w-0 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 truncate"
+                  className="ios-field flex-1 min-w-0 truncate"
                 >
                   {listColumns.map(c => (<option key={c.id} value={c.id}>{c.name}</option>))}
                 </select>
@@ -2619,7 +2642,7 @@ export default function App() {
                   setQuickRule(v);
                   if (v === "custom") setShowAddAdvanced(true);
                 }}
-                className="shrink-0 w-fit px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+                className="ios-field shrink-0 w-fit"
                 title="Recurrence"
               >
                 <option value="none">No recurrence</option>
@@ -2662,17 +2685,23 @@ export default function App() {
                       scrollable={settings.inlineAdd}
                       footer={settings.inlineAdd ? (
                         <form
-                          className="mt-2 flex gap-1"
+                          className="mt-2 flex items-center gap-2"
                           onSubmit={(e) => { e.preventDefault(); addInlineTask(String(day)); }}
                         >
                           <input
                             ref={el => setInlineInputRef(String(day), el)}
                             value={inlineTitles[String(day)] || ""}
                             onChange={(e) => setInlineTitles(prev => ({ ...prev, [String(day)]: e.target.value }))}
-                            className="flex-1 min-w-0 px-2 py-1 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
+                            className="ios-field flex-1 min-w-0"
                             placeholder="Add task"
                           />
-                          <button type="submit" className="rounded-xl bg-emerald-600 hover:bg-emerald-500">+</button>
+                          <button
+                            type="submit"
+                            className="ios-icon-button bg-emerald-600 hover:bg-emerald-500 text-white"
+                            aria-label="Add task"
+                          >
+                            +
+                          </button>
                         </form>
                       ) : undefined}
                     >
@@ -2708,17 +2737,23 @@ export default function App() {
                     scrollable={settings.inlineAdd}
                     footer={settings.inlineAdd ? (
                       <form
-                        className="mt-2 flex gap-1"
+                        className="mt-2 flex items-center gap-2"
                         onSubmit={(e) => { e.preventDefault(); addInlineTask("bounties"); }}
                       >
                         <input
                           ref={el => setInlineInputRef("bounties", el)}
                           value={inlineTitles["bounties"] || ""}
                           onChange={(e) => setInlineTitles(prev => ({ ...prev, bounties: e.target.value }))}
-                          className="flex-1 min-w-0 px-2 py-1 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
+                          className="ios-field flex-1 min-w-0"
                           placeholder="Add task"
                         />
-                        <button type="submit" className="rounded-xl bg-emerald-600 hover:bg-emerald-500">+</button>
+                        <button
+                          type="submit"
+                          className="ios-icon-button bg-emerald-600 hover:bg-emerald-500 text-white"
+                          aria-label="Add task"
+                        >
+                          +
+                        </button>
                       </form>
                     ) : undefined}
                   >
@@ -2764,17 +2799,23 @@ export default function App() {
                     scrollable={settings.inlineAdd}
                     footer={settings.inlineAdd ? (
                       <form
-                        className="mt-2 flex gap-1"
+                        className="mt-2 flex items-center gap-2"
                         onSubmit={(e) => { e.preventDefault(); addInlineTask(col.id); }}
                       >
                         <input
                           ref={el => setInlineInputRef(col.id, el)}
                           value={inlineTitles[col.id] || ""}
                           onChange={(e) => setInlineTitles(prev => ({ ...prev, [col.id]: e.target.value }))}
-                          className="flex-1 min-w-0 px-2 py-1 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
+                          className="ios-field flex-1 min-w-0"
                           placeholder="Add task"
                         />
-                        <button type="submit" className="rounded-xl bg-emerald-600 hover:bg-emerald-500">+</button>
+                        <button
+                          type="submit"
+                          className="ios-icon-button bg-emerald-600 hover:bg-emerald-500 text-white"
+                          aria-label="Add task"
+                        >
+                          +
+                        </button>
                       </form>
                     ) : undefined}
                   >
@@ -2805,11 +2846,11 @@ export default function App() {
         ) : (
           // Completed view
           <div className="rounded-2xl bg-neutral-900/60 border border-neutral-800 p-4">
-            <div className="flex items-center gap-2 mb-3">
+            <div className="flex items-center gap-3 mb-3">
               <div className="text-lg font-semibold">Completed</div>
               <div className="ml-auto">
                 <button
-                  className="px-3 py-2 rounded-xl bg-rose-600/80 hover:bg-rose-600"
+                  className="ios-pill-button bg-rose-600/80 hover:bg-rose-600 text-white"
                   onClick={clearCompleted}
                 >
                   Clear completed
@@ -2819,9 +2860,9 @@ export default function App() {
             {completed.length === 0 ? (
               <div className="text-neutral-400 text-sm">No completed tasks yet.</div>
             ) : (
-              <ul className="space-y-2">
+              <ul className="space-y-3">
                 {completed.map((t) => (
-                  <li key={t.id} className="task px-3 rounded-xl bg-neutral-800 border border-neutral-700">
+                  <li key={t.id} className="task ios-task-card bg-neutral-800 border border-neutral-700">
                     <div className="flex items-start gap-2">
                       <div className="flex-1">
                       <div className="text-sm font-medium leading-[1.15]">
@@ -2874,7 +2915,7 @@ export default function App() {
       {/* Floating Upcoming Drawer Button */}
       <button
         ref={upcomingButtonRef}
-        className={`fixed bottom-4 right-4 px-3 py-2 rounded-full bg-neutral-800 border border-neutral-700 shadow-lg text-sm transition-transform ${upcomingHover ? 'scale-110' : ''}`}
+        className={`ios-pill-button fixed bottom-4 right-4 bg-neutral-800 border border-neutral-700 shadow-lg transition-transform ${upcomingHover ? 'scale-110' : ''}`}
         onClick={() => setShowUpcoming(true)}
         title="Upcoming (hidden) tasks"
         onDragOver={(e) => { e.preventDefault(); setUpcomingHover(true); }}
@@ -2895,9 +2936,9 @@ export default function App() {
           {upcoming.length === 0 ? (
             <div className="text-sm text-neutral-400">No upcoming tasks.</div>
           ) : (
-            <ul className="space-y-2">
+            <ul className="space-y-3">
               {upcoming.map((t) => (
-                <li key={t.id} className="task px-3 rounded-xl bg-neutral-900 border border-neutral-800">
+                <li key={t.id} className="task ios-task-card bg-neutral-900 border border-neutral-800">
                   <div className="flex items-start gap-2">
                     <div className="flex-1">
                       <div className="text-sm font-medium leading-[1.15]">{renderTitleWithLink(t.title, t.note)}</div>
@@ -2920,9 +2961,9 @@ export default function App() {
                       ) : null}
                     </div>
                   </div>
-                  <div className="mt-2 flex gap-2">
+                  <div className="mt-3 flex gap-2">
                     <button
-                      className="px-3 py-1 rounded-full bg-emerald-600 hover:bg-emerald-500 text-sm"
+                      className="ios-pill-button bg-emerald-600 hover:bg-emerald-500 text-white"
                       onClick={() =>
                         setTasks((prev) =>
                           prev.map((x) =>
@@ -2934,7 +2975,7 @@ export default function App() {
                       Reveal now
                     </button>
                     <button
-                      className="px-3 py-1 rounded-full bg-neutral-700 hover:bg-neutral-600 text-sm"
+                      className="ios-pill-button bg-neutral-700 hover:bg-neutral-600"
                       onClick={() => { setEditing(t); setShowUpcoming(false); }}
                     >
                       Edit
@@ -3389,7 +3430,7 @@ function Card({
   return (
     <div
       ref={cardRef}
-      className="task group relative px-2 rounded-xl bg-neutral-800 border border-neutral-700 select-none"
+      className="task ios-task-card group relative bg-neutral-800 border border-neutral-700 select-none"
       // Allow horizontal swiping across columns on mobile
       style={{ touchAction: "auto" }}
       draggable
@@ -3413,7 +3454,7 @@ function Card({
             }}
             aria-label="Mark incomplete"
             title="Mark incomplete"
-            className="flex items-center justify-center w-8 h-8 rounded-full text-emerald-500"
+            className="ios-icon-button text-emerald-500"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" className="pointer-events-none">
               <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" strokeWidth="2" />
@@ -3429,7 +3470,7 @@ function Card({
             }}
             aria-label="Complete task"
             title="Mark complete"
-            className="flex items-center justify-center w-8 h-8 rounded-full text-neutral-300 hover:text-emerald-500 transition"
+            className="ios-icon-button text-neutral-300 hover:text-emerald-500"
           >
             <svg width="20" height="20" viewBox="0 0 24 24" className="pointer-events-none">
               <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" strokeWidth="2" />
@@ -3492,7 +3533,7 @@ function Card({
 function IconButton({
   children, onClick, label, intent, buttonRef
 }: React.PropsWithChildren<{ onClick: ()=>void; label: string; intent?: "danger"|"success"; buttonRef?: React.Ref<HTMLButtonElement> }>) {
-  const base = "w-9 h-9 rounded-full inline-flex items-center justify-center text-sm border border-transparent bg-neutral-700/40 hover:bg-neutral-700/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500";
+  const base = "ios-icon-button border border-transparent bg-neutral-700/40 hover:bg-neutral-700/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500";
   const danger = " border-rose-700";
   const success = " bg-emerald-700/30 hover:bg-emerald-700/50";
   const cls = base + (intent==="danger" ? danger : intent==="success" ? success : "");
@@ -3624,7 +3665,14 @@ function EditModal({ task, onCancel, onDelete, onSave, weekStart, onRedeemCoins 
             {images.map((img, i) => (
               <div key={i} className="relative">
                 <img src={img} className="max-h-40 rounded-lg" />
-                <button type="button" className="absolute top-1 right-1 bg-black/70 rounded-full px-1 text-xs" onClick={() => setImages(images.filter((_, j) => j !== i))}>×</button>
+                <button
+                  type="button"
+                  data-compact
+                  className="absolute top-1 right-1 bg-black/70 rounded-full px-1 text-xs"
+                  onClick={() => setImages(images.filter((_, j) => j !== i))}
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
@@ -3643,18 +3691,19 @@ function EditModal({ task, onCancel, onDelete, onSave, weekStart, onRedeemCoins 
                 className="accent-emerald-600"
               />
               <input
-                className="flex-1 px-2 py-1 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
+                className="ios-field flex-1 px-2 py-1 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
                 value={st.title}
                 onChange={(e) => setSubtasks(prev => prev.map(s => s.id === st.id ? { ...s, title: e.target.value } : s))}
                 placeholder="Subtask"
               />
-              <button
-                type="button"
-                className="text-sm text-rose-500"
-                onClick={() => setSubtasks(prev => prev.filter(s => s.id !== st.id))}
-              >
-                ✕
-              </button>
+            <button
+              type="button"
+              className="ios-icon-button text-rose-500 hover:bg-rose-600/20"
+              aria-label="Remove subtask"
+              onClick={() => setSubtasks(prev => prev.filter(s => s.id !== st.id))}
+            >
+              ✕
+            </button>
             </div>
           ))}
           <div className="flex items-center gap-2 mt-2">
@@ -3664,11 +3713,11 @@ function EditModal({ task, onCancel, onDelete, onSave, weekStart, onRedeemCoins 
               onChange={e=>setNewSubtask(e.target.value)}
               onKeyDown={e=>{ if (e.key === "Enter") { e.preventDefault(); addSubtask(true); } }}
               placeholder="New subtask…"
-              className="flex-1 px-2 py-1 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
+              className="ios-field flex-1 px-2 py-1 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
             />
             <button
               type="button"
-              className="text-sm px-2 py-1 rounded bg-neutral-800"
+              className="ios-pill-button text-sm bg-neutral-800 hover:bg-neutral-700"
               onClick={() => addSubtask()}
             >
               Add
@@ -3699,7 +3748,14 @@ function EditModal({ task, onCancel, onDelete, onSave, weekStart, onRedeemCoins 
             <button className="pressable px-3 py-2 rounded-xl bg-neutral-800" onClick={() => setRule({ type: "daily" })}>Daily</button>
             <button className="pressable px-3 py-2 rounded-xl bg-neutral-800" onClick={() => setRule({ type: "weekly", days: [1,2,3,4,5] })}>Mon–Fri</button>
             <button className="pressable px-3 py-2 rounded-xl bg-neutral-800" onClick={() => setRule({ type: "weekly", days: [0,6] })}>Weekends</button>
-            <button className="pressable ml-auto px-3 py-2 rounded-xl bg-neutral-800" onClick={() => setShowAdvanced(true)} title="Advanced recurrence…">Advanced…</button>
+            <button
+              className="pressable ml-auto rounded-full bg-neutral-800"
+              data-compact
+              onClick={() => setShowAdvanced(true)}
+              title="Advanced recurrence…"
+            >
+              Advanced…
+            </button>
           </div>
         </div>
 
@@ -3834,7 +3890,7 @@ function EditModal({ task, onCancel, onDelete, onSave, weekStart, onRedeemCoins 
                 </div>
               ) : (
                 <textarea readOnly value={task.bounty.token || ""}
-                          className="w-full px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800" rows={3}/>
+                          className="ios-field w-full px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800" rows={3}/>
               )}
               <div className="flex gap-2 flex-wrap">
                 {task.bounty.token && (
@@ -4694,11 +4750,11 @@ function SettingsModal({
       onPrimaryAction();
     }
     const buttonClasses = hidden
-      ? "flex-1 text-left min-w-0 text-neutral-300 hover:text-neutral-100 transition-colors"
-      : "flex-1 text-left min-w-0";
+      ? "flex-1 min-w-0 text-left text-neutral-300 hover:text-neutral-100 transition-colors"
+      : "flex-1 min-w-0 text-left";
     return (
       <li
-        className="relative p-2 rounded-lg bg-neutral-800 border border-neutral-700 flex items-center gap-2"
+        className="relative ios-task-card border border-neutral-800 bg-neutral-900/70 flex items-center gap-3 transition hover:bg-neutral-800"
         draggable
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
@@ -4710,7 +4766,7 @@ function SettingsModal({
           <div className="absolute -top-[0.125rem] left-0 right-0 h-[0.1875rem] bg-emerald-500 rounded-full" />
         )}
         <button type="button" className={buttonClasses} onClick={handleClick}>
-          <span className="flex items-center gap-2">
+          <span className="flex items-center gap-2 text-base font-medium">
             {hidden && (
               <span className="shrink-0" aria-hidden="true">
                 <HiddenBoardIcon />
@@ -4723,7 +4779,8 @@ function SettingsModal({
         {hidden && onEdit && (
           <button
             type="button"
-            className="px-3 py-1 rounded-full bg-neutral-700 hover:bg-neutral-600"
+            className="pressable rounded-full bg-neutral-700 hover:bg-neutral-600"
+            data-compact
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -4759,7 +4816,7 @@ function SettingsModal({
     function handleDragLeave() { setOverBefore(false); }
     return (
       <li
-        className="relative p-2 rounded-lg bg-neutral-800 border border-neutral-700 flex items-center gap-2"
+        className="relative ios-task-card border border-neutral-800 bg-neutral-900/70 flex items-center gap-3 transition hover:bg-neutral-800"
         draggable
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
@@ -4769,10 +4826,10 @@ function SettingsModal({
         {overBefore && (
           <div className="absolute -top-[0.125rem] left-0 right-0 h-[0.1875rem] bg-emerald-500 rounded-full" />
         )}
-        <div className="flex-1">{column.name}</div>
+        <div className="flex-1 text-base font-medium">{column.name}</div>
         <div className="flex gap-1">
-          <button className="px-3 py-1 rounded-full bg-neutral-700 hover:bg-neutral-600" onClick={()=>renameColumn(boardId, column.id)}>Rename</button>
-          <button className="pressable px-3 py-1 rounded-full bg-rose-600/80 hover:bg-rose-600" onClick={()=>deleteColumn(boardId, column.id)}>Delete</button>
+          <button className="pressable rounded-full bg-neutral-700 hover:bg-neutral-600" data-compact onClick={()=>renameColumn(boardId, column.id)}>Rename</button>
+          <button className="pressable rounded-full bg-rose-600/80 hover:bg-rose-600" data-compact onClick={()=>deleteColumn(boardId, column.id)}>Delete</button>
         </div>
       </li>
     );
@@ -4816,7 +4873,7 @@ function SettingsModal({
         {/* Boards & Columns */}
         <section className="rounded-xl border border-neutral-800 p-3 bg-neutral-900/60">
           <div className="flex items-center gap-2 mb-3">
-            <div className="text-sm font-medium">Boards & Lists</div>
+            <div className="text-base font-semibold">Boards & Lists</div>
           </div>
           <ul
             ref={boardListRef}
@@ -4839,17 +4896,17 @@ function SettingsModal({
               value={newBoardName}
               onChange={e=>setNewBoardName(e.target.value)}
               placeholder="Board name or ID"
-              className="flex-1 min-w-0 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+              className="ios-field flex-1 min-w-0"
             />
             <button
-              className="pressable px-3 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-500 shrink-0"
+              className="pressable ios-pill-button bg-emerald-600 hover:bg-emerald-500 shrink-0"
               onClick={addBoard}
             >
               Create/Join
             </button>
           </div>
           <button
-            className={`pressable mt-2 px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700 transition ${archiveDropActive ? "ring-2 ring-emerald-500" : ""}`}
+            className={`pressable mt-2 ios-pill-button bg-neutral-900/80 border border-neutral-800 hover:bg-neutral-800 transition ${archiveDropActive ? "ring-2 ring-emerald-500" : ""}`}
             onClick={() => setShowArchivedBoards(true)}
             onDragEnter={handleArchiveButtonDragEnter}
             onDragOver={handleArchiveButtonDragOver}
@@ -4863,10 +4920,11 @@ function SettingsModal({
         {/* View */}
         <section className="rounded-xl border border-neutral-800 p-3 bg-neutral-900/60">
           <div className="flex items-center gap-2 mb-3">
-            <div className="text-sm font-medium">View</div>
+            <div className="text-base font-semibold">View</div>
             <div className="ml-auto" />
             <button
-              className="px-3 py-1 rounded-lg bg-neutral-800 text-xs"
+              className="pressable rounded-full bg-neutral-800"
+              data-compact
               onClick={() => setShowViewAdvanced((v) => !v)}
             >
               {showViewAdvanced ? "Hide advanced" : "Advanced"}
@@ -4874,7 +4932,7 @@ function SettingsModal({
           </div>
           <div className="space-y-4">
             <div>
-              <div className="text-sm font-medium mb-2">Theme</div>
+              <div className="text-base font-semibold mb-2">Theme</div>
               <div className="flex gap-2">
                 <button className={`px-3 py-2 rounded-xl ${settings.theme === "system" ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ theme: "system" })}>System</button>
                 <button className={`px-3 py-2 rounded-xl ${settings.theme === "light" ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ theme: "light" })}>Light</button>
@@ -4882,7 +4940,7 @@ function SettingsModal({
               </div>
             </div>
             <div>
-              <div className="text-sm font-medium mb-2">Font size</div>
+              <div className="text-base font-semibold mb-2">Font size</div>
               <div className="flex gap-2 flex-wrap">
                 <button
                   className={`px-3 py-2 rounded-xl ${settings.baseFontSize == null ? "bg-emerald-600" : "bg-neutral-800"}`}
@@ -4905,17 +4963,17 @@ function SettingsModal({
                   onClick={() => setSettings({ baseFontSize: 22 })}
                 >X-Large</button>
               </div>
-              <div className="text-xs text-neutral-400 mt-2">Scales the entire UI. Defaults to a larger reading size.</div>
+              <div className="text-sm text-neutral-400 mt-2">Scales the entire UI. Defaults to a larger reading size.</div>
             </div>
             <div>
-              <div className="text-sm font-medium mb-2">Add new tasks to</div>
+              <div className="text-base font-semibold mb-2">Add new tasks to</div>
               <div className="flex gap-2">
                 <button className={`px-3 py-2 rounded-xl ${settings.newTaskPosition === 'top' ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ newTaskPosition: 'top' })}>Top</button>
                 <button className={`px-3 py-2 rounded-xl ${settings.newTaskPosition === 'bottom' ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ newTaskPosition: 'bottom' })}>Bottom</button>
               </div>
             </div>
             <div>
-              <div className="text-sm font-medium mb-2">Add tasks within lists</div>
+              <div className="text-base font-semibold mb-2">Add tasks within lists</div>
               <div className="flex gap-2">
                 <button className={`px-3 py-2 rounded-xl ${settings.inlineAdd ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ inlineAdd: true })}>Inline</button>
                 <button className={`px-3 py-2 rounded-xl ${!settings.inlineAdd ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ inlineAdd: false })}>Top bar</button>
@@ -4925,16 +4983,16 @@ function SettingsModal({
           {showViewAdvanced && (
             <div className="mt-4 border-t border-neutral-800 pt-4 space-y-4">
               <div>
-                <div className="text-sm font-medium mb-2">Week starts on</div>
+                <div className="text-base font-semibold mb-2">Week starts on</div>
                 <div className="flex gap-2">
                   <button className={`px-3 py-2 rounded-xl ${settings.weekStart === 6 ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ weekStart: 6 })}>Saturday</button>
                   <button className={`px-3 py-2 rounded-xl ${settings.weekStart === 0 ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ weekStart: 0 })}>Sunday</button>
                   <button className={`px-3 py-2 rounded-xl ${settings.weekStart === 1 ? "bg-emerald-600" : "bg-neutral-800"}`} onClick={() => setSettings({ weekStart: 1 })}>Monday</button>
                 </div>
-                <div className="text-xs text-neutral-400 mt-2">Affects when weekly recurring tasks re-appear.</div>
+                <div className="text-sm text-neutral-400 mt-2">Affects when weekly recurring tasks re-appear.</div>
               </div>
               <div>
-                <div className="text-sm font-medium mb-2">Show full week for recurring tasks</div>
+                <div className="text-base font-semibold mb-2">Show full week for recurring tasks</div>
                 <div className="flex gap-2">
                   <button
                     className={`px-3 py-2 rounded-xl ${settings.showFullWeekRecurring ? "bg-emerald-600" : "bg-neutral-800"}`}
@@ -4943,10 +5001,10 @@ function SettingsModal({
                     {settings.showFullWeekRecurring ? "On" : "Off"}
                   </button>
                 </div>
-                <div className="text-xs text-neutral-400 mt-2">Display all occurrences for the current week at once.</div>
+                <div className="text-sm text-neutral-400 mt-2">Display all occurrences for the current week at once.</div>
               </div>
               <div>
-                <div className="text-sm font-medium mb-2">Completed tab</div>
+                <div className="text-base font-semibold mb-2">Completed tab</div>
                 <div className="flex gap-2">
                   <button
                     className={`px-3 py-2 rounded-xl ${settings.completedTab ? "bg-emerald-600" : "bg-neutral-800"}`}
@@ -4955,10 +5013,10 @@ function SettingsModal({
                     {settings.completedTab ? "On" : "Off"}
                   </button>
                 </div>
-                <div className="text-xs text-neutral-400 mt-2">Hide the completed tab and show a Clear completed button instead.</div>
+                <div className="text-sm text-neutral-400 mt-2">Hide the completed tab and show a Clear completed button instead.</div>
               </div>
               <div>
-                <div className="text-sm font-medium mb-2">Streaks</div>
+                <div className="text-base font-semibold mb-2">Streaks</div>
                 <div className="flex gap-2">
                   <button
                     className={`px-3 py-2 rounded-xl ${settings.streaksEnabled ? "bg-emerald-600" : "bg-neutral-800"}`}
@@ -4967,16 +5025,16 @@ function SettingsModal({
                     {settings.streaksEnabled ? "On" : "Off"}
                   </button>
                 </div>
-                <div className="text-xs text-neutral-400 mt-2">Track consecutive completions on recurring tasks.</div>
+                <div className="text-sm text-neutral-400 mt-2">Track consecutive completions on recurring tasks.</div>
               </div>
               <div>
-                <div className="text-sm font-medium mb-2">Board on app start</div>
+                <div className="text-base font-semibold mb-2">Board on app start</div>
                 <div className="space-y-2">
                   {WD_FULL.map((label, idx) => (
                     <div key={label} className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
                       <div className="text-xs uppercase tracking-wide text-neutral-400 sm:w-28">{label}</div>
                       <select
-                        className="flex-1 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+                        className="ios-field flex-1"
                         value={settings.startBoardByDay[idx as Weekday] ?? ""}
                         onChange={(e) => handleDailyStartBoardChange(idx as Weekday, e.target.value)}
                       >
@@ -4990,7 +5048,7 @@ function SettingsModal({
                     </div>
                   ))}
                 </div>
-                <div className="text-xs text-neutral-400 mt-2">
+                <div className="text-sm text-neutral-400 mt-2">
                   Choose which board opens first for each day. Perfect for work boards on weekdays and personal lists on weekends.
                 </div>
               </div>
@@ -5001,17 +5059,18 @@ function SettingsModal({
         {/* Nostr */}
         <section className="rounded-xl border border-neutral-800 p-3 bg-neutral-900/60">
           <div className="flex items-center gap-2 mb-3">
-            <div className="text-sm font-medium">Nostr</div>
+            <div className="text-base font-semibold">Nostr</div>
             <div className="ml-auto" />
             <button
-              className="px-3 py-1 rounded-lg bg-neutral-800 text-xs"
+              className="pressable rounded-full bg-neutral-800"
+              data-compact
               onClick={()=>setShowAdvanced(a=>!a)}
             >{showAdvanced ? "Hide advanced" : "Advanced"}</button>
           </div>
           {/* Quick actions available outside Advanced */}
           <div className="mb-3 flex gap-2">
             <button
-              className="px-3 py-2 rounded-xl bg-neutral-800"
+              className="ios-pill-button bg-neutral-800"
               onClick={async ()=>{
                 try {
                   const sk = localStorage.getItem(LS_NOSTR_SK) || "";
@@ -5029,7 +5088,7 @@ function SettingsModal({
               }}
             >Copy nsec</button>
             <button
-              className="px-3 py-2 rounded-xl bg-neutral-800"
+              className="ios-pill-button bg-neutral-800"
               onClick={()=>setDefaultRelays(DEFAULT_RELAYS.slice())}
             >Reload default relays</button>
           </div>
@@ -5037,17 +5096,17 @@ function SettingsModal({
             <>
               {/* Public key */}
               <div className="mb-3">
-                <div className="text-xs text-neutral-400 mb-1">Your Nostr public key (hex)</div>
+              <div className="text-sm text-neutral-400 mb-1">Your Nostr public key (hex)</div>
                 <div className="flex gap-2 items-center">
                   <input readOnly value={pubkeyHex || "(generating…)"}
-                         className="flex-1 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"/>
+                         className="ios-field flex-1 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"/>
                   <button className="px-3 py-2 rounded-xl bg-neutral-800" onClick={async ()=>{ if(pubkeyHex) { try { await navigator.clipboard?.writeText(pubkeyHex); } catch {} } }}>Copy</button>
                 </div>
               </div>
 
               {/* Private key options */}
               <div className="mb-3 space-y-2">
-                <div className="text-xs text-neutral-400 mb-1">Custom Nostr private key (hex or nsec)</div>
+                <div className="text-sm text-neutral-400 mb-1">Custom Nostr private key (hex or nsec)</div>
                 <div className="flex gap-2 items-center">
                   <input value={customSk} onChange={e=>setCustomSk(e.target.value)}
                          className="flex-1 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800" placeholder="nsec or hex"/>
@@ -5078,7 +5137,7 @@ function SettingsModal({
 
               {/* Default relays */}
               <div className="mb-3">
-                <div className="text-xs text-neutral-400 mb-1">Default relays</div>
+              <div className="text-sm text-neutral-400 mb-1">Default relays</div>
                 <div className="flex gap-2 mb-2">
                   <input
                     value={newDefaultRelay}
@@ -5115,24 +5174,24 @@ function SettingsModal({
 
         {/* Backup & Restore */}
         <section className="rounded-xl border border-neutral-800 p-3 bg-neutral-900/60">
-          <div className="text-sm font-medium mb-3">Backup</div>
+          <div className="text-base font-semibold mb-3">Backup</div>
           <div className="flex gap-2">
-            <button className="flex-1 px-3 py-2 rounded-xl bg-neutral-800" onClick={backupData}>Download backup</button>
-            <label className="flex-1 px-3 py-2 rounded-xl bg-neutral-800 text-center cursor-pointer">
+            <button className="flex-1 pressable ios-pill-button bg-neutral-800" onClick={backupData}>Download backup</button>
+            <label className="flex-1 pressable ios-pill-button bg-neutral-800 text-center cursor-pointer">
               Restore from backup
-              <input type="file" accept="application/json" className="hidden" onChange={restoreFromBackup} />
+              <input type="file" accept="application/json" className="ios-field hidden" onChange={restoreFromBackup} />
             </label>
           </div>
         </section>
 
         {/* Tutorial */}
         <section className="rounded-xl border border-neutral-800 p-3 bg-neutral-900/60">
-          <div className="text-sm font-medium mb-2">Tutorial</div>
-          <div className="text-xs text-neutral-400 mb-3">
+          <div className="text-base font-semibold mb-2">Tutorial</div>
+          <div className="text-sm text-neutral-400 mb-3">
             Replay the guided tour to refresh how Taskify works.
           </div>
           <button
-            className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700"
+            className="pressable ios-pill-button bg-neutral-800 hover:bg-neutral-700"
             onClick={onRestartTutorial}
           >
             View tutorial again
@@ -5141,29 +5200,29 @@ function SettingsModal({
 
         {/* Development donation */}
         <section className="rounded-xl border border-neutral-800 p-3 bg-neutral-900/60">
-          <div className="text-sm font-medium mb-2">Support development</div>
-          <div className="text-xs text-neutral-400 mb-3">Donate from your internal wallet to dev@solife.me</div>
+          <div className="text-base font-semibold mb-2">Support development</div>
+          <div className="text-sm text-neutral-400 mb-3">Donate from your internal wallet to dev@solife.me</div>
           <div className="flex gap-2 mb-2 w-full">
             <input
-              className="min-w-[7rem] flex-1 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+              className="ios-field min-w-[7rem] flex-1"
               placeholder="Amount (sats)"
               value={donateAmt}
               onChange={(e)=>setDonateAmt(e.target.value)}
               inputMode="numeric"
             />
             <button
-              className="shrink-0 px-3 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-500 whitespace-nowrap"
+              className="pressable shrink-0 ios-pill-button bg-emerald-600 hover:bg-emerald-500 whitespace-nowrap"
               onClick={handleDonate}
               disabled={!mintUrl || donateState === 'sending'}
             >Donate Now</button>
           </div>
           <input
-            className="w-full px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+            className="ios-field w-full"
             placeholder="Comment (optional)"
             value={donateComment}
             onChange={(e)=>setDonateComment(e.target.value)}
           />
-          <div className="mt-2 text-xs">
+          <div className="mt-2 text-sm">
             {donateState === 'sending' && <span>Sending…</span>}
             {donateState === 'done' && <span className="text-emerald-400">{donateMsg}</span>}
             {donateState === 'error' && <span className="text-rose-400">{donateMsg}</span>}
@@ -5172,7 +5231,7 @@ function SettingsModal({
 
         {/* Feedback / Feature requests */}
         <section>
-          <div className="text-xs text-neutral-400">
+          <div className="text-sm text-neutral-400">
             Please submit any feedback or feature requests to{' '}
             <button
               className="underline text-emerald-400"
@@ -5186,20 +5245,20 @@ function SettingsModal({
         </section>
 
         <div className="flex justify-end">
-          <button className="px-3 py-2 rounded-xl bg-neutral-800" onClick={handleClose}>Close</button>
+          <button className="pressable ios-pill-button bg-neutral-800" onClick={handleClose}>Close</button>
         </div>
       </div>
     </Modal>
     {showArchivedBoards && (
       <Modal onClose={() => setShowArchivedBoards(false)} title="Archived boards">
         {archivedBoards.length === 0 ? (
-          <div className="text-sm text-neutral-400">No archived boards.</div>
+          <div className="text-base text-neutral-400">No archived boards.</div>
         ) : (
           <ul className="space-y-2">
             {archivedBoards.map((b) => (
               <li
                 key={b.id}
-                className="p-2 rounded-lg bg-neutral-800 border border-neutral-700 flex items-center gap-2 cursor-pointer hover:bg-neutral-700"
+                className="ios-task-card border border-neutral-800 bg-neutral-900/70 flex items-center gap-3 cursor-pointer hover:bg-neutral-800 transition"
                 role="button"
                 tabIndex={0}
                 onClick={() => openArchivedBoard(b.id)}
@@ -5210,10 +5269,11 @@ function SettingsModal({
                   }
                 }}
               >
-                <div className="flex-1 truncate">{b.name}</div>
+                <div className="flex-1 truncate text-base font-medium">{b.name}</div>
                 <div className="flex gap-2">
                   <button
-                    className="pressable px-3 py-1 rounded-full bg-neutral-700 hover:bg-neutral-600"
+                    className="pressable rounded-full bg-neutral-700 hover:bg-neutral-600"
+                    data-compact
                     onClick={(e) => {
                       e.stopPropagation();
                       unarchiveBoard(b.id);
@@ -5222,7 +5282,8 @@ function SettingsModal({
                     Unarchive
                   </button>
                   <button
-                    className="pressable px-3 py-1 rounded-full bg-rose-600/80 hover:bg-rose-600"
+                    className="pressable rounded-full bg-rose-600/80 hover:bg-rose-600"
+                    data-compact
                     onClick={(e) => {
                       e.stopPropagation();
                       deleteBoard(b.id);
@@ -5242,7 +5303,7 @@ function SettingsModal({
         <input
           value={manageBoard.name}
           onChange={e => renameBoard(manageBoard.id, e.target.value)}
-          className="w-full mb-4 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+          className="ios-field w-full mb-4"
         />
         {manageBoard.kind === "lists" ? (
           <>
@@ -5252,54 +5313,62 @@ function SettingsModal({
               ))}
             </ul>
             <div className="mt-2">
-              <button className="pressable px-3 py-2 rounded-xl bg-neutral-800" onClick={()=>addColumn(manageBoard.id)}>Add list</button>
+              <button className="pressable ios-pill-button bg-neutral-800" onClick={()=>addColumn(manageBoard.id)}>Add list</button>
             </div>
-            <div className="text-xs text-neutral-400 mt-2">Tasks can be dragged between lists directly on the board.</div>
+            <div className="text-sm text-neutral-400 mt-2">Tasks can be dragged between lists directly on the board.</div>
           </>
         ) : (
-          <div className="text-xs text-neutral-400">The Week board has fixed columns (Sun–Sat, Bounties).</div>
+          <div className="text-sm text-neutral-400">The Week board has fixed columns (Sun–Sat, Bounties).</div>
         )}
 
         <div className="mt-6">
           <div className="flex items-center gap-2 mb-2">
-            <div className="text-sm font-medium">Sharing</div>
+            <div className="text-base font-semibold">Sharing</div>
             <div className="ml-auto" />
             <button
-              className="px-3 py-1 rounded-lg bg-neutral-800 text-xs"
+              className="pressable rounded-full bg-neutral-800"
+              data-compact
               onClick={()=>setShowAdvanced(a=>!a)}
             >{showAdvanced ? "Hide advanced" : "Advanced"}</button>
           </div>
           <div className="space-y-2">
             {manageBoard.nostr ? (
               <>
-                <div className="text-xs text-neutral-400">Board ID</div>
+                <div className="text-sm text-neutral-400">Board ID</div>
                 <div className="flex gap-2 items-center">
-                  <input readOnly value={manageBoard.nostr.boardId}
-                         className="flex-1 min-w-0 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"/>
-                  <button className="px-3 py-2 rounded-xl bg-neutral-800" onClick={async ()=>{ try { await navigator.clipboard?.writeText(manageBoard.nostr!.boardId); } catch {} }}>Copy</button>
+                  <input
+                    readOnly
+                    value={manageBoard.nostr.boardId}
+                    className="ios-field flex-1 min-w-0"
+                  />
+                  <button
+                    className="pressable ios-pill-button bg-neutral-800"
+                    onClick={async ()=>{ try { await navigator.clipboard?.writeText(manageBoard.nostr!.boardId); } catch {} }}
+                  >Copy</button>
                 </div>
                   {showAdvanced && (
                     <>
-                      <div className="text-xs text-neutral-400">Relays</div>
+                      <div className="text-sm text-neutral-400">Relays</div>
                       <div className="flex gap-2 mb-2">
                         <input
                           value={newBoardRelay}
                           onChange={(e)=>setNewBoardRelay(e.target.value)}
                           onKeyDown={(e)=>{ if (e.key === 'Enter' && manageBoard?.nostr) { const v = newBoardRelay.trim(); if (v && !(manageBoard.nostr.relays || []).includes(v)) { setBoards(prev => prev.map(b => b.id === manageBoard.id ? ({...b, nostr: { boardId: manageBoard.nostr!.boardId, relays: [...(manageBoard.nostr!.relays || []), v] } }) : b)); setNewBoardRelay(""); } } }}
-                          className="flex-1 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+                          className="ios-field flex-1"
                           placeholder="wss://relay.example"
                         />
                         <button
-                          className="px-3 py-2 rounded-xl bg-neutral-800"
+                          className="pressable ios-pill-button bg-neutral-800"
                           onClick={()=>{ if (!manageBoard?.nostr) return; const v = newBoardRelay.trim(); if (v && !(manageBoard.nostr.relays || []).includes(v)) { setBoards(prev => prev.map(b => b.id === manageBoard.id ? ({...b, nostr: { boardId: manageBoard.nostr!.boardId, relays: [...(manageBoard.nostr!.relays || []), v] } }) : b)); setNewBoardRelay(""); } }}
                         >Add</button>
                       </div>
                       <ul className="space-y-2 mb-2">
                         {(manageBoard.nostr.relays || []).map((r) => (
-                          <li key={r} className="p-2 rounded-lg bg-neutral-800 border border-neutral-700 flex items-center gap-2">
-                            <div className="flex-1 truncate">{r}</div>
+                          <li key={r} className="ios-task-card border border-neutral-800 bg-neutral-900/70 flex items-center gap-3">
+                            <div className="flex-1 truncate text-base font-medium">{r}</div>
                             <button
-                              className="pressable px-3 py-1 rounded-full bg-rose-600/80 hover:bg-rose-600"
+                              className="pressable rounded-full bg-rose-600/80 hover:bg-rose-600"
+                              data-compact
                               onClick={()=>{
                                 if (!manageBoard?.nostr) return;
                                 const relays = (manageBoard.nostr.relays || []).filter(x => x !== r);
@@ -5309,15 +5378,15 @@ function SettingsModal({
                           </li>
                         ))}
                       </ul>
-                      <button className="px-3 py-2 rounded-xl bg-neutral-800" onClick={()=>onRegenerateBoardId(manageBoard.id)}>Generate new board ID</button>
+                      <button className="pressable ios-pill-button bg-neutral-800" onClick={()=>onRegenerateBoardId(manageBoard.id)}>Generate new board ID</button>
                     </>
                   )}
                   <div className="flex gap-2">
                   <button
-                    className="px-3 py-2 rounded-xl bg-neutral-800"
+                    className="pressable ios-pill-button bg-neutral-800"
                     onClick={()=>onBoardChanged(manageBoard.id, { republishTasks: true })}
                   >Republish metadata</button>
-                  <button className="px-3 py-2 rounded-xl bg-rose-600/80 hover:bg-rose-600" onClick={()=>{
+                  <button className="pressable ios-pill-button bg-rose-600/80 hover:bg-rose-600" onClick={()=>{
                     setBoards(prev => prev.map(b => b.id === manageBoard.id ? (b.kind === 'week'
                       ? { id: b.id, name: b.name, kind: 'week', archived: b.archived, hidden: b.hidden } as Board
                       : { id: b.id, name: b.name, kind: 'lists', columns: b.columns, archived: b.archived, hidden: b.hidden } as Board
@@ -5329,54 +5398,54 @@ function SettingsModal({
               <>
                 {showAdvanced && (
                   <>
-                    <div className="text-xs text-neutral-400">Relays override (optional)</div>
+                    <div className="text-sm text-neutral-400">Relays override (optional)</div>
                     <div className="flex gap-2 mb-2">
                       <input
                         value={newOverrideRelay}
                         onChange={(e)=>setNewOverrideRelay(e.target.value)}
                         onKeyDown={(e)=>{ if (e.key === 'Enter') { const v = newOverrideRelay.trim(); if (v) { setRelaysCsv(addRelayToCsv(relaysCsv, v)); setNewOverrideRelay(""); } } }}
-                        className="flex-1 px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800"
+                        className="ios-field flex-1"
                         placeholder="wss://relay.example"
                       />
-                      <button className="px-3 py-2 rounded-xl bg-neutral-800" onClick={()=>{ const v = newOverrideRelay.trim(); if (v) { setRelaysCsv(addRelayToCsv(relaysCsv, v)); setNewOverrideRelay(""); } }}>Add</button>
+                      <button className="pressable ios-pill-button bg-neutral-800" onClick={()=>{ const v = newOverrideRelay.trim(); if (v) { setRelaysCsv(addRelayToCsv(relaysCsv, v)); setNewOverrideRelay(""); } }}>Add</button>
                     </div>
                     <ul className="space-y-2 mb-2">
                       {parseCsv(relaysCsv).map((r) => (
-                        <li key={r} className="p-2 rounded-lg bg-neutral-800 border border-neutral-700 flex items-center gap-2">
-                          <div className="flex-1 truncate">{r}</div>
-                          <button className="pressable px-3 py-1 rounded-full bg-rose-600/80 hover:bg-rose-600" onClick={()=>setRelaysCsv(removeRelayFromCsv(relaysCsv, r))}>Delete</button>
+                        <li key={r} className="ios-task-card border border-neutral-800 bg-neutral-900/70 flex items-center gap-3">
+                          <div className="flex-1 truncate text-base font-medium">{r}</div>
+                          <button className="pressable rounded-full bg-rose-600/80 hover:bg-rose-600" data-compact onClick={()=>setRelaysCsv(removeRelayFromCsv(relaysCsv, r))}>Delete</button>
                         </li>
                       ))}
                     </ul>
                   </>
                 )}
-                <button className="block w-full px-3 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-500" onClick={()=>{onShareBoard(manageBoard.id, showAdvanced ? relaysCsv : ""); setRelaysCsv('');}}>Share this board</button>
+                <button className="pressable ios-pill-button w-full bg-emerald-600 hover:bg-emerald-500" onClick={()=>{onShareBoard(manageBoard.id, showAdvanced ? relaysCsv : ""); setRelaysCsv('');}}>Share this board</button>
               </>
             )}
             <div className="mt-4 flex gap-2">
               <button
-                className="pressable flex-1 px-3 py-2 rounded-xl bg-neutral-700 hover:bg-neutral-600"
+                className="pressable ios-pill-button flex-1 bg-neutral-700 hover:bg-neutral-600"
                 onClick={() => setBoardHidden(manageBoard.id, !manageBoard.hidden)}
               >
                 {manageBoard.hidden ? "Unhide board" : "Hide board"}
               </button>
               {!manageBoard.archived ? (
                 <button
-                  className="pressable flex-1 px-3 py-2 rounded-xl bg-neutral-700 hover:bg-neutral-600"
+                  className="pressable ios-pill-button flex-1 bg-neutral-700 hover:bg-neutral-600"
                   onClick={() => archiveBoard(manageBoard.id)}
                 >
                   Archive board
                 </button>
               ) : (
                 <button
-                  className="pressable flex-1 px-3 py-2 rounded-xl bg-neutral-700 hover:bg-neutral-600"
+                  className="pressable ios-pill-button flex-1 bg-neutral-700 hover:bg-neutral-600"
                   onClick={() => unarchiveBoard(manageBoard.id)}
                 >
                   Unarchive board
                 </button>
               )}
             </div>
-            <button className="pressable mt-2 block w-full px-3 py-2 rounded-xl bg-rose-600/80 hover:bg-rose-600" onClick={()=>deleteBoard(manageBoard.id)}>Delete board</button>
+            <button className="pressable mt-2 ios-pill-button w-full bg-rose-600/80 hover:bg-rose-600" onClick={()=>deleteBoard(manageBoard.id)}>Delete board</button>
           </div>
         </div>
       </Modal>

--- a/taskify-pwa/src/components/CashuWalletModal.tsx
+++ b/taskify-pwa/src/components/CashuWalletModal.tsx
@@ -243,7 +243,7 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
       </ActionSheet>
 
       <ActionSheet open={receiveMode === "ecash"} onClose={()=>{setReceiveMode(null); setShowReceiveOptions(false); setRecvTokenStr(""); setRecvMsg("");}} title="Receive eCash">
-        <textarea ref={recvRef} className="w-full h-24 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste Cashu token (cashuA...)" value={recvTokenStr} onChange={(e)=>setRecvTokenStr(e.target.value)} />
+        <textarea ref={recvRef} className="ios-field w-full h-24 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste Cashu token (cashuA...)" value={recvTokenStr} onChange={(e)=>setRecvTokenStr(e.target.value)} />
         <div className="mt-2 flex gap-2 items-center">
           <button
             className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700"
@@ -263,13 +263,13 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
 
       <ActionSheet open={receiveMode === "lightning"} onClose={()=>{setReceiveMode(null); setShowReceiveOptions(false);}} title="Mint via Lightning">
         <div className="flex gap-2 mb-2">
-          <input className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={mintAmt} onChange={(e)=>setMintAmt(e.target.value)} />
+          <input className="ios-field flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={mintAmt} onChange={(e)=>setMintAmt(e.target.value)} />
           <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleCreateInvoice} disabled={!mintUrl}>Get Invoice</button>
         </div>
         {mintQuote && (
           <div className="text-xs bg-neutral-950 border border-neutral-800 rounded-xl p-2">
             <div className="mb-1">Invoice:</div>
-            <textarea readOnly className="w-full h-20 bg-transparent outline-none" value={mintQuote.request} />
+            <textarea readOnly className="ios-field w-full h-20 bg-transparent outline-none" value={mintQuote.request} />
             <div className="flex gap-2 mt-2">
               <a className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" href={`lightning:${mintQuote.request}`}>Open Wallet</a>
               <button
@@ -293,12 +293,12 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
 
       <ActionSheet open={sendMode === "ecash"} onClose={()=>{setSendMode(null); setShowSendOptions(false);}} title="Send eCash">
         <div className="flex gap-2 mb-2">
-          <input className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={sendAmt} onChange={(e)=>setSendAmt(e.target.value)} />
+          <input className="ios-field flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={sendAmt} onChange={(e)=>setSendAmt(e.target.value)} />
           <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleCreateSendToken} disabled={!mintUrl}>Create Token</button>
         </div>
         {sendTokenStr && (
           <div className="text-xs bg-neutral-950 border border-neutral-800 rounded-xl p-2">
-            <textarea readOnly className="w-full h-24 bg-transparent outline-none" value={sendTokenStr} />
+            <textarea readOnly className="ios-field w-full h-24 bg-transparent outline-none" value={sendTokenStr} />
             <div className="mt-2">
               <button
                 className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700"
@@ -310,9 +310,9 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
       </ActionSheet>
 
       <ActionSheet open={sendMode === "lightning"} onClose={()=>{setSendMode(null); setShowSendOptions(false); setLnInput(""); setLnAddrAmt(""); setLnState("idle"); setLnError("");}} title="Pay Lightning Invoice">
-        <textarea ref={lnRef} className="w-full h-20 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste BOLT11 invoice or enter lightning address" value={lnInput} onChange={(e)=>setLnInput(e.target.value)} />
+        <textarea ref={lnRef} className="ios-field w-full h-20 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste BOLT11 invoice or enter lightning address" value={lnInput} onChange={(e)=>setLnInput(e.target.value)} />
         {isLnAddress && (
-          <input className="mt-2 w-full px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={lnAddrAmt} onChange={(e)=>setLnAddrAmt(e.target.value)} />
+          <input className="ios-field mt-2 w-full px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={lnAddrAmt} onChange={(e)=>setLnAddrAmt(e.target.value)} />
         )}
         <div className="mt-2 flex gap-2">
           <button
@@ -341,7 +341,7 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
                 <button className="w-full text-left" onClick={()=>setExpandedIdx(expandedIdx===i?null:i)}>{h.summary}</button>
                 {expandedIdx === i && h.detail && (
                   <div className="mt-1">
-                    <textarea readOnly className="w-full h-24 bg-neutral-950 border border-neutral-800 rounded-xl p-2" value={h.detail} />
+                    <textarea readOnly className="ios-field w-full h-24 bg-neutral-950 border border-neutral-800 rounded-xl p-2" value={h.detail} />
                     <button
                       className="mt-1 px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700"
                       onClick={async ()=>{ try { await navigator.clipboard.writeText(h.detail!); } catch {} }}
@@ -363,7 +363,7 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
             <div className="text-xs text-neutral-400 mb-1">Active mint</div>
             <div className="flex gap-2 items-center">
               <input
-                className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800"
+                className="ios-field flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800"
                 value={mintInputSheet}
                 onChange={(e)=>setMintInputSheet(e.target.value)}
                 placeholder="https://mint.minibits.cash/Bitcoin"

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -19,9 +19,9 @@
 
 /* Ensure app fills screen */
 :root {
-  /* Larger default reading size */
+  /* Align with native iOS sizing */
   font: -apple-system-body;
-  font-size: 18px;
+  font-size: 17px;
   -webkit-text-size-adjust: 100%;
 }
 
@@ -76,19 +76,75 @@ button, input, select, textarea {
               border-color 0.2s ease, opacity 0.2s ease;
 }
 
-/* Compact spacing for buttons, tasks, and textboxes */
+/* iOS-inspired control sizing */
 @layer base {
-  button,
+  button:not([data-compact]),
   select {
-    padding: 0.125rem 0.5rem !important;
+    border-radius: 9999px !important;
+    min-height: 2.75rem;
+    padding: 0.6rem 1.2rem !important;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
   }
 
-  /* Reduce vertical padding for inputs and textareas */
-  input,
-  textarea,
-  .task {
-    padding-top: 0.125rem !important;
-    padding-bottom: 0.125rem !important;
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([data-compact]),
+  textarea:not([data-compact]) {
+    border-radius: 9999px !important;
+    min-height: 2.75rem;
+    padding: 0.6rem 1rem !important;
+    font-size: 1rem;
+    line-height: 1.2;
+  }
+
+  button[data-compact] {
+    border-radius: 9999px !important;
+    min-height: 2rem;
+    padding: 0.35rem 0.85rem !important;
+    font-size: 0.82rem;
+    font-weight: 600;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+  }
+}
+
+@layer components {
+  .ios-pill-button {
+    @apply inline-flex items-center justify-center rounded-full font-semibold transition-colors;
+    min-height: 2.75rem;
+    padding: 0.6rem 1.2rem !important;
+    font-size: 1rem;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+  }
+
+  .ios-icon-button {
+    @apply inline-flex items-center justify-center rounded-full p-0 transition-colors;
+    width: 2.75rem;
+    height: 2.75rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    padding: 0 !important;
+  }
+
+  .ios-field {
+    @apply rounded-full border border-neutral-800 bg-neutral-900 text-white placeholder:text-neutral-500 transition focus:outline-none focus:ring-2 focus:ring-emerald-500/60 focus:border-emerald-500/60;
+    min-height: 2.75rem;
+    padding: 0.6rem 1rem !important;
+    font-size: 1rem;
+    line-height: 1.2;
+  }
+
+  .ios-task-card {
+    @apply rounded-full px-4 py-3;
+    border-radius: 9999px !important;
+  }
+
+  .wallet-icon {
+    display: inline-block;
+    font-size: 1.1rem;
+    line-height: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- resize the header icon buttons and add sr-only labels so the settings and wallet symbols match the rest of the UI scale
- restyle board lists, archived items, and manage board controls with the new pill field/button system plus refreshed section typography in settings
- add a reusable data-compact style that shrinks advanced toggles and apply it across settings and board management actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9c1bb3f5c8324b62f3a3fec4f90f5