### PR TITLE
Tune settings list sizing and icon scaling

### DIFF
--- a/taskify-pwa/src/components/CashuWalletModal.tsx
+++ b/taskify-pwa/src/components/CashuWalletModal.tsx
@@ -243,7 +243,7 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
       </ActionSheet>
 
       <ActionSheet open={receiveMode === "ecash"} onClose={()=>{setReceiveMode(null); setShowReceiveOptions(false); setRecvTokenStr(""); setRecvMsg("");}} title="Receive eCash">
-        <textarea ref={recvRef} className="w-full h-24 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste Cashu token (cashuA...)" value={recvTokenStr} onChange={(e)=>setRecvTokenStr(e.target.value)} />
+        <textarea ref={recvRef} className="ios-field w-full h-24 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste Cashu token (cashuA...)" value={recvTokenStr} onChange={(e)=>setRecvTokenStr(e.target.value)} />
         <div className="mt-2 flex gap-2 items-center">
           <button
             className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700"
@@ -263,13 +263,13 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
 
       <ActionSheet open={receiveMode === "lightning"} onClose={()=>{setReceiveMode(null); setShowReceiveOptions(false);}} title="Mint via Lightning">
         <div className="flex gap-2 mb-2">
-          <input className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={mintAmt} onChange={(e)=>setMintAmt(e.target.value)} />
+          <input className="ios-field flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={mintAmt} onChange={(e)=>setMintAmt(e.target.value)} />
           <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleCreateInvoice} disabled={!mintUrl}>Get Invoice</button>
         </div>
         {mintQuote && (
           <div className="text-xs bg-neutral-950 border border-neutral-800 rounded-xl p-2">
             <div className="mb-1">Invoice:</div>
-            <textarea readOnly className="w-full h-20 bg-transparent outline-none" value={mintQuote.request} />
+            <textarea readOnly className="ios-field w-full h-20 bg-transparent outline-none" value={mintQuote.request} />
             <div className="flex gap-2 mt-2">
               <a className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700" href={`lightning:${mintQuote.request}`}>Open Wallet</a>
               <button
@@ -293,12 +293,12 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
 
       <ActionSheet open={sendMode === "ecash"} onClose={()=>{setSendMode(null); setShowSendOptions(false);}} title="Send eCash">
         <div className="flex gap-2 mb-2">
-          <input className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={sendAmt} onChange={(e)=>setSendAmt(e.target.value)} />
+          <input className="ios-field flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={sendAmt} onChange={(e)=>setSendAmt(e.target.value)} />
           <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handleCreateSendToken} disabled={!mintUrl}>Create Token</button>
         </div>
         {sendTokenStr && (
           <div className="text-xs bg-neutral-950 border border-neutral-800 rounded-xl p-2">
-            <textarea readOnly className="w-full h-24 bg-transparent outline-none" value={sendTokenStr} />
+            <textarea readOnly className="ios-field w-full h-24 bg-transparent outline-none" value={sendTokenStr} />
             <div className="mt-2">
               <button
                 className="px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700"
@@ -310,9 +310,9 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
       </ActionSheet>
 
       <ActionSheet open={sendMode === "lightning"} onClose={()=>{setSendMode(null); setShowSendOptions(false); setLnInput(""); setLnAddrAmt(""); setLnState("idle"); setLnError("");}} title="Pay Lightning Invoice">
-        <textarea ref={lnRef} className="w-full h-20 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste BOLT11 invoice or enter lightning address" value={lnInput} onChange={(e)=>setLnInput(e.target.value)} />
+        <textarea ref={lnRef} className="ios-field w-full h-20 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Paste BOLT11 invoice or enter lightning address" value={lnInput} onChange={(e)=>setLnInput(e.target.value)} />
         {isLnAddress && (
-          <input className="mt-2 w-full px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={lnAddrAmt} onChange={(e)=>setLnAddrAmt(e.target.value)} />
+          <input className="ios-field mt-2 w-full px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800" placeholder="Amount (sats)" value={lnAddrAmt} onChange={(e)=>setLnAddrAmt(e.target.value)} />
         )}
         <div className="mt-2 flex gap-2">
           <button
@@ -328,7 +328,7 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
           >Paste</button>
           <button className="px-3 py-2 rounded-xl bg-neutral-800 hover:bg-neutral-700" onClick={handlePayInvoice} disabled={!mintUrl || !lnInput || (isLnAddress && !lnAddrAmt)}>Pay</button>
           {lnState === "sending" && <div className="text-xs">Paying…</div>}
-          {lnState === "done" && <div className="text-xs text-emerald-400">Paid</div>}
+          {lnState === "done" && <div className="text-xs accent-text">Paid</div>}
           {lnState === "error" && <div className="text-xs text-rose-400">{lnError}</div>}
         </div>
       </ActionSheet>
@@ -341,7 +341,7 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
                 <button className="w-full text-left" onClick={()=>setExpandedIdx(expandedIdx===i?null:i)}>{h.summary}</button>
                 {expandedIdx === i && h.detail && (
                   <div className="mt-1">
-                    <textarea readOnly className="w-full h-24 bg-neutral-950 border border-neutral-800 rounded-xl p-2" value={h.detail} />
+                    <textarea readOnly className="ios-field w-full h-24 bg-neutral-950 border border-neutral-800 rounded-xl p-2" value={h.detail} />
                     <button
                       className="mt-1 px-3 py-1 rounded-lg bg-neutral-800 hover:bg-neutral-700"
                       onClick={async ()=>{ try { await navigator.clipboard.writeText(h.detail!); } catch {} }}
@@ -363,13 +363,13 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
             <div className="text-xs text-neutral-400 mb-1">Active mint</div>
             <div className="flex gap-2 items-center">
               <input
-                className="flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800"
+                className="ios-field flex-1 px-3 py-2 rounded-xl bg-neutral-950 border border-neutral-800"
                 value={mintInputSheet}
                 onChange={(e)=>setMintInputSheet(e.target.value)}
                 placeholder="https://mint.minibits.cash/Bitcoin"
               />
               <button
-                className="px-3 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-500"
+                className="px-3 py-2 rounded-xl accent-button"
                 onClick={async ()=>{ try { await setMintUrl(mintInputSheet.trim()); refreshMintEntries(); } catch (e: any) { alert(e?.message || String(e)); } }}
               >Save</button>
             </div>
@@ -401,7 +401,7 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
                       onClick={async ()=>{ try { await navigator.clipboard?.writeText(m.url); } catch {} }}
                     >Copy</button>
                     {m.url !== mintUrl && (
-                      <button className="px-2 py-1 rounded bg-emerald-700/70 hover:bg-emerald-600 text-xs" onClick={async ()=>{ try { await setMintUrl(m.url); refreshMintEntries(); } catch (e: any) { alert(e?.message || String(e)); } }}>Set active</button>
+                      <button className="px-2 py-1 rounded accent-soft-surface text-xs" onClick={async ()=>{ try { await setMintUrl(m.url); refreshMintEntries(); } catch (e: any) { alert(e?.message || String(e)); } }}>Set active</button>
                     )}
                   </div>
                 ))}

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -14,15 +14,35 @@
 }
 .pressable:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.35);
+  box-shadow: 0 0 0 2px var(--accent-ring);
 }
 
 /* Ensure app fills screen */
 :root {
-  /* Larger default reading size */
+  /* Align with native iOS sizing */
   font: -apple-system-body;
-  font-size: 18px;
+  font-size: 17px;
   -webkit-text-size-adjust: 100%;
+
+  --accent-solid: #059669;
+  --accent-solid-hover: #34d399;
+  --accent-ring: rgba(16, 185, 129, 0.65);
+  --accent-soft-bg: rgba(16, 185, 129, 0.18);
+  --accent-soft-bg-hover: rgba(16, 185, 129, 0.24);
+  --accent-soft-border: rgba(16, 185, 129, 0.45);
+  --accent-soft-text: #6ee7b7;
+  --accent-contrast: #f8fafc;
+}
+
+:root[data-accent="blue"] {
+  --accent-solid: #007aff;
+  --accent-solid-hover: #2997ff;
+  --accent-ring: rgba(0, 122, 255, 0.65);
+  --accent-soft-bg: rgba(0, 122, 255, 0.2);
+  --accent-soft-bg-hover: rgba(0, 122, 255, 0.26);
+  --accent-soft-border: rgba(0, 122, 255, 0.45);
+  --accent-soft-text: #8fc2ff;
+  --accent-contrast: #f8fafc;
 }
 
 html,
@@ -76,19 +96,188 @@ button, input, select, textarea {
               border-color 0.2s ease, opacity 0.2s ease;
 }
 
-/* Compact spacing for buttons, tasks, and textboxes */
+/* iOS-inspired control sizing */
 @layer base {
-  button,
+  button:not([data-compact]),
   select {
-    padding: 0.125rem 0.5rem !important;
+    border-radius: 9999px !important;
+    min-height: 2.6rem;
+    padding: 0.55rem 1.1rem !important;
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.05;
+    letter-spacing: -0.01em;
   }
 
-  /* Reduce vertical padding for inputs and textareas */
-  input,
-  textarea,
-  .task {
-    padding-top: 0.125rem !important;
-    padding-bottom: 0.125rem !important;
+  input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]):not([data-compact]),
+  textarea:not([data-compact]) {
+    border-radius: 9999px !important;
+    min-height: 2.6rem;
+    padding: 0.55rem 0.95rem !important;
+    font-size: 0.95rem;
+    line-height: 1.2;
+  }
+
+  button[data-compact] {
+    border-radius: 9999px !important;
+    min-height: 2rem;
+    padding: 0.35rem 0.85rem !important;
+    font-size: 0.82rem;
+    font-weight: 600;
+    line-height: 1.1;
+    letter-spacing: -0.01em;
+  }
+}
+
+@layer components {
+  .ios-pill-button {
+    @apply inline-flex items-center justify-center rounded-full font-semibold transition-colors;
+    min-height: 2.6rem;
+    padding: 0.55rem 1.05rem !important;
+    font-size: 0.95rem;
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+  }
+
+  .ios-icon-button {
+    @apply inline-flex items-center justify-center rounded-full transition-colors;
+    width: 2.6rem;
+    height: 2.6rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+
+  .ios-field {
+    @apply rounded-full bg-neutral-900 text-white placeholder:text-neutral-500 transition;
+    border: 1px solid #27272a;
+    min-height: 2.6rem;
+    padding: 0.55rem 0.95rem !important;
+    font-size: 0.95rem;
+    line-height: 1.2;
+  }
+
+  .ios-field:focus {
+    outline: none;
+    border-color: var(--accent-soft-border);
+    box-shadow: 0 0 0 2px var(--accent-ring);
+  }
+
+  .ios-task-card {
+    @apply rounded-full;
+    border-radius: 9999px !important;
+    padding: 0.55rem 1rem;
+    transition: border-radius 160ms ease;
+  }
+
+  .ios-task-card[data-multiline="true"] {
+    border-radius: 1.1rem !important;
+  }
+
+  .ios-settings-item {
+    @apply rounded-full bg-neutral-900/70 border border-neutral-800;
+    border-radius: 9999px !important;
+    min-height: 2.6rem;
+    padding: 0.4rem 0.9rem;
+    transition: border-radius 160ms ease, background-color 160ms ease;
+  }
+
+  .ios-settings-item[data-multiline="true"] {
+    border-radius: 1.1rem !important;
+  }
+
+  .ios-task-complete {
+    width: 2.9rem !important;
+    height: 2.9rem !important;
+  }
+
+  .wallet-icon {
+    display: inline-block;
+    font-size: 1.1rem;
+    line-height: 1;
+  }
+
+  .accent-button {
+    background-color: var(--accent-solid) !important;
+    border-color: var(--accent-solid) !important;
+    color: var(--accent-contrast) !important;
+  }
+
+  .accent-button:hover {
+    background-color: var(--accent-solid-hover) !important;
+    border-color: var(--accent-solid-hover) !important;
+  }
+
+  .accent-surface {
+    background-color: var(--accent-solid) !important;
+    border-color: var(--accent-solid) !important;
+    color: var(--accent-contrast) !important;
+  }
+
+  .accent-surface:hover {
+    background-color: var(--accent-solid-hover) !important;
+    border-color: var(--accent-solid-hover) !important;
+  }
+
+  .accent-soft-surface {
+    background-color: var(--accent-soft-bg) !important;
+    border-color: var(--accent-soft-border) !important;
+    color: var(--accent-soft-text) !important;
+  }
+
+  .accent-soft-surface:hover {
+    background-color: var(--accent-soft-bg-hover) !important;
+    border-color: var(--accent-soft-border) !important;
+  }
+
+  .accent-icon {
+    color: var(--accent-solid) !important;
+  }
+
+  .accent-icon-hover:hover {
+    color: var(--accent-solid) !important;
+  }
+
+  .accent-text {
+    color: var(--accent-soft-text) !important;
+  }
+
+  .accent-link {
+    color: var(--accent-soft-text);
+  }
+
+  .accent-link:hover {
+    color: var(--accent-solid);
+  }
+
+  .accent-hover-underline:hover {
+    text-decoration-color: var(--accent-solid) !important;
+  }
+
+  .accent-chip {
+    background-color: var(--accent-soft-bg);
+    border-color: var(--accent-soft-border) !important;
+    color: var(--accent-soft-text);
+  }
+
+  .accent-accent {
+    accent-color: var(--accent-solid);
+  }
+
+  .accent-focus {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+  }
+
+  .accent-focus:focus-visible {
+    outline-color: var(--accent-ring);
+  }
+
+  .accent-ring {
+    box-shadow: 0 0 0 2px var(--accent-ring);
+  }
+
+  .accent-border {
+    border-color: var(--accent-soft-border) !important;
   }
 }
 
@@ -105,10 +294,6 @@ button, input, select, textarea {
   background: #18181b; /* neutral-900 */
 }
 /* Light theme color adjustments */
-html.light button[class*="bg-emerald"] {
-  filter: brightness(1.15);
-}
-
 html.light button[class*="bg-rose"] {
   filter: brightness(0.9);
 }


### PR DESCRIPTION
## Summary
- align the settings board and list pills with the single-line text field height via a dedicated ios-settings-item style and typography tweaks
- enlarge the header completed toggle, per-task completion targets, and inline add icons for improved visual balance
- add reusable helpers to scale task completion controls while keeping the existing accent-aware styling intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9c1bb3f5c8324b62f3a3fec4f90f5