### PR TITLE
Reduce add bar padding

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2656,12 +2656,12 @@ export default function App() {
                 }
               }}
               placeholder="New task…"
-              className="pill-input flex-1 min-w-0"
+              className="pill-input add-bar-input flex-1 min-w-0"
             />
             <button
               ref={addButtonRef}
               onClick={() => addTask()}
-              className="accent-button shrink-0"
+              className="accent-button add-bar-button shrink-0"
             >
               Add
             </button>

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -199,6 +199,14 @@ button {
   color: var(--text-secondary);
 }
 
+.add-bar-input {
+  padding: 0.45rem 0.9rem;
+}
+
+.add-bar-button {
+  padding: 0.45rem 1rem;
+}
+
 select.pill-select {
   appearance: none;
   background-image: linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),


### PR DESCRIPTION
## Summary
- add add-bar specific utility classes so the top add task input and button use reduced padding
- apply the new classes to the add task bar to tighten its spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab56f281883248629d9426cca9003