### PR TITLE
Adjust accent defaults and inline layout polish

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -109,6 +109,38 @@ type Settings = {
   accent: "green" | "blue";
 };
 
+const ACCENT_CHOICES = [
+  {
+    id: "blue",
+    label: "iMessage blue",
+    fill: "#0a84ff",
+    ring: "rgba(64, 156, 255, 0.32)",
+    border: "rgba(64, 156, 255, 0.38)",
+    borderActive: "rgba(64, 156, 255, 0.88)",
+    shadow: "0 12px 26px rgba(10, 132, 255, 0.32)",
+    shadowActive: "0 18px 34px rgba(10, 132, 255, 0.42)",
+  },
+  {
+    id: "green",
+    label: "Mint green",
+    fill: "#34c759",
+    ring: "rgba(52, 199, 89, 0.28)",
+    border: "rgba(52, 199, 89, 0.36)",
+    borderActive: "rgba(52, 199, 89, 0.86)",
+    shadow: "0 12px 24px rgba(52, 199, 89, 0.28)",
+    shadowActive: "0 18px 32px rgba(52, 199, 89, 0.38)",
+  },
+] satisfies Array<{
+  id: Settings["accent"];
+  label: string;
+  fill: string;
+  ring: string;
+  border: string;
+  borderActive: string;
+  shadow: string;
+  shadowActive: string;
+}>;
+
 const R_NONE: Recurrence = { type: "none" };
 const LS_TASKS = "taskify_tasks_v4";
 const LS_SETTINGS = "taskify_settings_v2";
@@ -485,7 +517,7 @@ function useSettings() {
           startBoardByDay[day as Weekday] = value;
         }
       }
-      const accent = parsed?.accent === "blue" ? "blue" : "green";
+      const accent = parsed?.accent === "green" ? "green" : "blue";
       return {
         weekStart: 0,
         newTaskPosition: "top",
@@ -510,7 +542,7 @@ function useSettings() {
         baseFontSize: null,
         theme: "dark",
         startBoardByDay: {},
-        accent: "green",
+        accent: "blue",
       };
     }
   });
@@ -754,7 +786,7 @@ export default function App() {
   useEffect(() => {
     try {
       const root = document.documentElement;
-      if (settings.accent === "blue") root.setAttribute("data-accent", "blue");
+      if (settings.accent === "green") root.setAttribute("data-accent", "green");
       else root.removeAttribute("data-accent");
     } catch {}
   }, [settings.accent]);
@@ -2410,12 +2442,12 @@ export default function App() {
   const totalTutorialSteps = tutorialSteps.length;
 
   return (
-    <div className="min-h-screen px-4 py-6 sm:px-6 lg:px-8 text-primary">
-      <div className="mx-auto max-w-7xl space-y-6">
+    <div className="min-h-screen px-4 py-4 sm:px-6 lg:px-8 text-primary">
+      <div className="mx-auto max-w-7xl space-y-5">
         {/* Header */}
-        <header className="space-y-4">
+        <header className="space-y-3">
           <div className="flex flex-wrap items-end gap-3">
-            <div className="flex flex-col gap-1 justify-end -translate-y-1">
+            <div className="flex flex-col gap-1 justify-end -translate-y-[2px]">
               <h1 className="text-3xl font-semibold tracking-tight">
                 Taskify
               </h1>
@@ -2930,11 +2962,11 @@ export default function App() {
                         </div>
                         <TaskMedia task={t} />
                         {t.subtasks?.length ? (
-                          <ul className="mt-1 space-y-1">
+                          <ul className="mt-1 space-y-1 text-xs">
                             {t.subtasks.map(st => (
-                              <li key={st.id} className="flex items-center gap-2 text-xs">
-                                <input type="checkbox" checked={!!st.completed} disabled/>
-                                <span className={st.completed ? 'line-through text-secondary' : ''}>{st.title}</span>
+                              <li key={st.id} className="subtask-row">
+                                <input type="checkbox" checked={!!st.completed} disabled className="subtask-row__checkbox" />
+                                <span className={`subtask-row__text ${st.completed ? 'line-through text-secondary' : ''}`}>{st.title}</span>
                               </li>
                             ))}
                           </ul>
@@ -2998,11 +3030,11 @@ export default function App() {
                       </div>
                       <TaskMedia task={t} />
                       {t.subtasks?.length ? (
-                        <ul className="mt-1 space-y-1">
+                        <ul className="mt-1 space-y-1 text-xs">
                           {t.subtasks.map(st => (
-                            <li key={st.id} className="flex items-center gap-2 text-xs">
-                              <input type="checkbox" checked={!!st.completed} disabled/>
-                              <span className={st.completed ? 'line-through text-secondary' : ''}>{st.title}</span>
+                            <li key={st.id} className="subtask-row">
+                              <input type="checkbox" checked={!!st.completed} disabled className="subtask-row__checkbox" />
+                              <span className={`subtask-row__text ${st.completed ? 'line-through text-secondary' : ''}`}>{st.title}</span>
                             </li>
                           ))}
                         </ul>
@@ -3411,7 +3443,15 @@ const DroppableColumn = React.forwardRef<HTMLDivElement, {
     <div
       ref={setRef}
       data-column-title={title}
-      className={`surface-panel w-[288px] shrink-0 p-4 ${scrollable ? 'flex h-[calc(100vh-12rem)] flex-col' : 'min-h-[320px]'}`}
+      className={`surface-panel w-[288px] shrink-0 p-4 ${scrollable ? 'flex h-[calc(100vh-8.5rem)] flex-col overflow-hidden' : 'min-h-[320px]'}`}
+      style={
+        scrollable
+          ? {
+              height: 'calc(100vh - 8.5rem - env(safe-area-inset-bottom))',
+              paddingBottom: 'calc(1rem + env(safe-area-inset-bottom))',
+            }
+          : undefined
+      }
       // No touchAction lock so horizontal scrolling stays fluid
       {...props}
     >
@@ -3431,8 +3471,11 @@ const DroppableColumn = React.forwardRef<HTMLDivElement, {
       >
         {title}
       </div>
-      <div className={`space-y-2 ${scrollable ? 'flex-1 overflow-y-auto pr-1' : ''}`}>{children}</div>
-      {footer}
+      <div className={scrollable ? 'flex-1 min-h-0 overflow-y-auto pr-1 pb-3' : ''}>
+        <div className="space-y-2">{children}</div>
+      </div>
+      {scrollable && footer ? <div className="mt-3 flex-shrink-0">{footer}</div> : null}
+      {!scrollable && footer}
     </div>
   );
 });
@@ -3628,13 +3671,14 @@ function Card({
       {task.subtasks?.length ? (
         <ul className="task-card__details mt-2 space-y-1.5 text-xs text-secondary">
           {task.subtasks.map((st) => (
-            <li key={st.id} className="flex items-center gap-2">
+            <li key={st.id} className="subtask-row">
               <input
                 type="checkbox"
                 checked={!!st.completed}
                 onChange={() => onToggleSubtask(st.id)}
+                className="subtask-row__checkbox"
               />
-              <span className={st.completed ? 'line-through text-tertiary' : 'text-secondary'}>{st.title}</span>
+              <span className={`subtask-row__text ${st.completed ? 'line-through text-tertiary' : 'text-secondary'}`}>{st.title}</span>
             </li>
           ))}
         </ul>
@@ -5100,9 +5144,30 @@ function SettingsModal({
             <div className="mt-4 border-t border-neutral-800 pt-4 space-y-4">
               <div>
                 <div className="text-sm font-medium mb-2">Accent color</div>
-                <div className="flex gap-2">
-                  <button className={pillButtonClass(settings.accent === 'green')} onClick={() => setSettings({ accent: 'green' })}>Mint green</button>
-                  <button className={pillButtonClass(settings.accent === 'blue')} onClick={() => setSettings({ accent: 'blue' })}>iMessage blue</button>
+                <div className="flex gap-3">
+                  {ACCENT_CHOICES.map((choice) => {
+                    const active = settings.accent === choice.id;
+                    return (
+                      <button
+                        key={choice.id}
+                        type="button"
+                        className={`accent-swatch pressable ${active ? 'accent-swatch--active' : ''}`}
+                        style={{
+                          "--swatch-color": choice.fill,
+                          "--swatch-ring": choice.ring,
+                          "--swatch-border": choice.border,
+                          "--swatch-border-active": choice.borderActive,
+                          "--swatch-shadow": choice.shadow,
+                          "--swatch-active-shadow": choice.shadowActive,
+                        } as React.CSSProperties}
+                        aria-label={choice.label}
+                        aria-pressed={active}
+                        onClick={() => setSettings({ accent: choice.id })}
+                      >
+                        <span className="sr-only">{choice.label}</span>
+                      </button>
+                    );
+                  })}
                 </div>
                 <div className="text-xs text-secondary mt-2">Switch the highlight color used across buttons, badges, and focus states.</div>
               </div>

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -10,13 +10,13 @@
   -webkit-text-size-adjust: 100%;
   color-scheme: dark;
 
-  --accent: #34c759;
-  --accent-hover: #2ac251;
-  --accent-active: #23ad47;
-  --accent-soft: rgba(52, 199, 89, 0.18);
-  --accent-border: rgba(52, 199, 89, 0.45);
-  --accent-on: #0a1f12;
-  --accent-glow: 0 16px 34px rgba(52, 199, 89, 0.28);
+  --accent: #0a84ff;
+  --accent-hover: #409cff;
+  --accent-active: #0060df;
+  --accent-soft: rgba(64, 156, 255, 0.2);
+  --accent-border: rgba(64, 156, 255, 0.45);
+  --accent-on: #061428;
+  --accent-glow: 0 18px 34px rgba(64, 156, 255, 0.28);
 
   --surface-base: #050508;
   --surface-raised: rgba(22, 23, 30, 0.88);
@@ -41,14 +41,14 @@
   --radius-tight: 18px;
 }
 
-html[data-accent="blue"] {
-  --accent: #0a84ff;
-  --accent-hover: #409cff;
-  --accent-active: #0060df;
-  --accent-soft: rgba(64, 156, 255, 0.2);
-  --accent-border: rgba(64, 156, 255, 0.45);
-  --accent-on: #061428;
-  --accent-glow: 0 18px 34px rgba(64, 156, 255, 0.28);
+html[data-accent="green"] {
+  --accent: #34c759;
+  --accent-hover: #2ac251;
+  --accent-active: #23ad47;
+  --accent-soft: rgba(52, 199, 89, 0.18);
+  --accent-border: rgba(52, 199, 89, 0.45);
+  --accent-on: #0a1f12;
+  --accent-glow: 0 16px 34px rgba(52, 199, 89, 0.28);
 }
 
 html.light {
@@ -77,10 +77,8 @@ body,
 }
 
 body {
-  background:
-    radial-gradient(circle at 18% -10%, rgba(88, 111, 255, 0.26), transparent 55%),
-    radial-gradient(circle at 82% -12%, rgba(28, 214, 168, 0.18), transparent 60%),
-    var(--surface-base);
+  position: relative;
+  background: var(--surface-base);
   color: var(--text-primary);
   font-family: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -92,8 +90,25 @@ body {
   transition: background-color 280ms ease;
 }
 
+body::before {
+  content: "";
+  position: fixed;
+  inset: -32vmax;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 18% -10%, rgba(88, 111, 255, 0.26), transparent 60%),
+    radial-gradient(circle at 82% -12%, rgba(28, 214, 168, 0.18), transparent 65%),
+    var(--surface-base);
+  transition: opacity 280ms ease;
+}
+
 html.light body {
-  background: linear-gradient(180deg, rgba(238, 243, 255, 0.96) 0%, rgba(247, 249, 255, 1) 30%, rgba(255, 255, 255, 1) 100%);
+  background: var(--surface-base);
+}
+
+html.light body::before {
+  background: linear-gradient(180deg, rgba(238, 243, 255, 0.96) 0%, rgba(247, 249, 255, 1) 38%, rgba(255, 255, 255, 1) 100%);
 }
 
 a {
@@ -247,6 +262,39 @@ input[type="radio"] {
   box-shadow: none;
 }
 
+.accent-swatch {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  border: 2px solid var(--swatch-border, rgba(255, 255, 255, 0.14));
+  background: var(--swatch-color, transparent);
+  box-shadow: var(--swatch-shadow, 0 12px 28px rgba(6, 12, 34, 0.32));
+  transition: transform 160ms ease, box-shadow 200ms ease, border-color 160ms ease;
+}
+
+.accent-swatch:hover {
+  transform: translateY(-1px);
+}
+
+.accent-swatch--active {
+  border-color: var(--swatch-border-active, rgba(255, 255, 255, 0.9));
+  box-shadow:
+    0 0 0 3px var(--swatch-ring, rgba(88, 111, 255, 0.28)),
+    var(--swatch-active-shadow, 0 18px 34px rgba(6, 12, 34, 0.45));
+}
+
+html.light .accent-swatch {
+  border-color: var(--swatch-border, rgba(12, 24, 63, 0.14));
+  box-shadow: var(--swatch-shadow, 0 10px 22px rgba(12, 26, 62, 0.16));
+}
+
+html.light .accent-swatch--active {
+  border-color: var(--swatch-border-active, rgba(12, 24, 63, 0.4));
+  box-shadow:
+    0 0 0 3px var(--swatch-ring, rgba(12, 24, 63, 0.18)),
+    var(--swatch-active-shadow, 0 14px 26px rgba(12, 26, 62, 0.18));
+}
+
 .ghost-button {
   display: inline-flex;
   align-items: center;
@@ -398,6 +446,24 @@ input[type="radio"] {
     border 160ms ease,
     box-shadow 160ms ease,
     border-radius 220ms ease;
+}
+
+.subtask-row {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+  margin-left: -1.1rem;
+  font-size: 0.75rem;
+}
+
+.subtask-row__checkbox {
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: none;
+}
+
+.subtask-row__text {
+  flex: 1;
 }
 
 .icon-button {


### PR DESCRIPTION
## Summary
- make blue the default accent and swap the accent picker to color-only swatches
- extend the background gradient coverage past safe areas and trim header spacing so cards sit higher on screen
- stabilize inline column heights so cards stay full-length, keep the inline add bar visible, and anchor the inline add form to the column bottom
- align subtask copy with task titles for cleaner card layouts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cab758bf2483248469e9d8c904381d