### PR TITLE
Match completion animation to accent color and avoid add-task zoom

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -1183,6 +1183,11 @@ export default function App() {
     const dotSize = 1.25 * rem; // 20px @ 16px base
     const dotFont = 0.875 * rem; // 14px @ 16px base
 
+    const rootStyles = getComputedStyle(document.documentElement);
+    const accent = rootStyles.getPropertyValue("--accent").trim() || "#34c759";
+    const accentSoft = rootStyles.getPropertyValue("--accent-soft").trim() || "rgba(52, 199, 89, 0.28)";
+    const accentOn = rootStyles.getPropertyValue("--accent-on").trim() || "#0a1f12";
+
     const dot = document.createElement('div');
     dot.style.position = 'fixed';
     dot.style.left = `${startX - dotSize / 2}px`;
@@ -1190,13 +1195,13 @@ export default function App() {
     dot.style.width = `${dotSize}px`;
     dot.style.height = `${dotSize}px`;
     dot.style.borderRadius = '9999px';
-    dot.style.background = '#10b981';
-    dot.style.color = 'white';
+    dot.style.background = accent;
+    dot.style.color = accentOn || '#ffffff';
     dot.style.display = 'grid';
     dot.style.placeItems = 'center';
     dot.style.fontSize = `${dotFont}px`;
     dot.style.lineHeight = `${dotSize}px`;
-    dot.style.boxShadow = '0 0 0 2px rgba(16,185,129,0.3), 0 6px 16px rgba(0,0,0,0.35)';
+    dot.style.boxShadow = `0 0 0 2px ${accentSoft || 'rgba(16,185,129,0.3)'}, 0 6px 16px rgba(0,0,0,0.35)`;
     dot.style.zIndex = '1000';
     dot.style.transform = 'translate(0, 0) scale(1)';
     dot.style.transition = 'transform 600ms cubic-bezier(.2,.7,.3,1), opacity 300ms ease 420ms';

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -188,7 +188,8 @@ button {
   border-radius: var(--radius-field);
   color: var(--text-primary);
   padding: 0.65rem 1rem;
-  font-size: 0.95rem;
+  font-size: max(16px, 0.95rem);
+  line-height: 1.35;
   box-shadow: var(--shadow-inner);
   backdrop-filter: var(--blur-backdrop);
   -webkit-backdrop-filter: var(--blur-backdrop);


### PR DESCRIPTION
## Summary
- update the fly-to-completed animation to read the active accent colors so the checkmark matches the chosen theme
- raise the minimum font size on pill inputs to prevent mobile browsers from zooming when typing new tasks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cacccaf3388324b77c6b8e09d89fa5