### PR TITLE
Style add task bar

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2692,14 +2692,17 @@ export default function App() {
                 }
               }}
               placeholder="New task…"
-              className="pill-input flex-1 min-w-0"
+              className="pill-input pill-input--compact flex-1 min-w-0"
             />
             <button
               ref={addButtonRef}
               onClick={() => addTask()}
-              className="accent-button shrink-0"
+              className="accent-button accent-button--circle pressable shrink-0"
+              type="button"
+              aria-label="Add task"
             >
-              Add
+              <span aria-hidden="true">+</span>
+              <span className="sr-only">Add task</span>
             </button>
             {newImages.length > 0 && (
               <div className="w-full flex gap-2 mt-2">

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -195,6 +195,12 @@ button {
   -webkit-backdrop-filter: var(--blur-backdrop);
 }
 
+.pill-input--compact {
+  min-height: 44px;
+  padding-top: 0.35rem;
+  padding-bottom: 0.35rem;
+}
+
 .pill-textarea {
   border-radius: var(--radius-card);
   resize: vertical;
@@ -246,6 +252,15 @@ input[type="radio"] {
   font-weight: 600;
   letter-spacing: -0.01em;
   box-shadow: var(--accent-glow);
+}
+
+.accent-button--circle {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border-radius: 50%;
+  font-size: 1.35rem;
+  line-height: 1;
 }
 
 .accent-button:hover {


### PR DESCRIPTION
## Summary
- shrink the add-task input styling and swap the add button for a circular control with a plus icon
- add compact pill input and circular accent button variants to keep the bar height consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad6121c9083249c94337ac3434afa