### PR TITLE
Adjust status bar color to match gradient

### DIFF
--- a/taskify-pwa/index.html
+++ b/taskify-pwa/index.html
@@ -6,9 +6,9 @@
     <title>Taskify</title>
     <meta name="apple-mobile-web-app-title" content="Taskify" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#0a0a0a" />
+    <meta name="theme-color" content="#101933" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- switch the iOS status bar style to black-translucent so the gradient can bleed through
- update the PWA theme color to a navy tone that matches the existing background gradient

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caefa0ee0483249a35f42c9c736818