### PR TITLE
Adjust status bar color to match gradient

### DIFF
--- a/taskify-pwa/index.html
+++ b/taskify-pwa/index.html
@@ -6,9 +6,9 @@
     <title>Taskify</title>
     <meta name="apple-mobile-web-app-title" content="Taskify" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#0a0a0a" />
+    <meta name="theme-color" content="#101933" />
   </head>
   <body>
     <div id="root"></div>

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -86,6 +86,7 @@ body {
   padding-top: env(safe-area-inset-top);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
   transition: background-color 280ms ease;
 }
 


### PR DESCRIPTION
## Summary
- switch the iOS status bar style to black-translucent so the gradient can bleed through
- update the PWA theme color to a navy tone that matches the existing background gradient
- add bottom safe-area padding so the gradient covers the home indicator area

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caefa0ee0483249a35f42c9c736818