### PR TITLE
Tint viewport background for safe areas

### DIFF
--- a/taskify-pwa/index.html
+++ b/taskify-pwa/index.html
@@ -6,9 +6,9 @@
     <title>Taskify</title>
     <meta name="apple-mobile-web-app-title" content="Taskify" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#0a0a0a" />
+    <meta name="theme-color" content="#101933" />
   </head>
   <body>
     <div id="root"></div>

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -76,6 +76,14 @@ body,
   overflow-x: hidden;
 }
 
+html {
+  background-color: #101933;
+}
+
+html.light {
+  background-color: #eef3ff;
+}
+
 body {
   position: relative;
   background: var(--surface-base);
@@ -86,13 +94,17 @@ body {
   padding-top: env(safe-area-inset-top);
   padding-left: env(safe-area-inset-left);
   padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
   transition: background-color 280ms ease;
 }
 
 body::before {
   content: "";
   position: fixed;
-  inset: -32vmax;
+  top: calc(-32vmax - env(safe-area-inset-top));
+  right: calc(-32vmax - env(safe-area-inset-right));
+  bottom: calc(-32vmax - env(safe-area-inset-bottom));
+  left: calc(-32vmax - env(safe-area-inset-left));
   z-index: -1;
   pointer-events: none;
   background:


### PR DESCRIPTION
## Summary
- add a navy fallback color to the html element so the safe-area background matches the gradient backdrop
- provide a light-theme override so the html background stays in sync with the light palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caefa0ee0483249a35f42c9c736818