### PR TITLE
Handle iOS safe areas for black translucent status bar

### DIFF
--- a/taskify-pwa/index.html
+++ b/taskify-pwa/index.html
@@ -6,9 +6,19 @@
     <title>Taskify</title>
     <meta name="apple-mobile-web-app-title" content="Taskify" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="theme-color" content="#0a0a0a" />
+    <script>
+      (function () {
+        function setAppHeight() {
+          document.documentElement.style.setProperty('--app-height', window.innerHeight + 'px');
+        }
+
+        setAppHeight();
+        window.addEventListener('resize', setAppHeight);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2446,8 +2446,8 @@ export default function App() {
   const totalTutorialSteps = tutorialSteps.length;
 
   return (
-    <div className="min-h-screen px-4 py-4 sm:px-6 lg:px-8 text-primary">
-      <div className="mx-auto max-w-7xl space-y-5">
+    <div className="app-shell">
+      <div className="mx-auto max-w-7xl space-y-5 px-4 py-4 sm:px-6 lg:px-8 text-primary">
         {/* Header */}
         <header className="relative space-y-3">
           <div ref={confettiRef} className="pointer-events-none absolute inset-x-0 -top-2 z-20 h-0" />
@@ -3025,7 +3025,11 @@ export default function App() {
       {/* Floating Upcoming Drawer Button */}
       <button
         ref={upcomingButtonRef}
-        className={`fixed bottom-4 right-4 px-3 py-2 rounded-full bg-surface-muted border border-surface shadow-lg text-sm transition-transform ${upcomingHover ? 'scale-110' : ''}`}
+        className={`fixed px-3 py-2 rounded-full bg-surface-muted border border-surface shadow-lg text-sm transition-transform ${upcomingHover ? 'scale-110' : ''}`}
+        style={{
+          bottom: 'calc(1rem + var(--safe-bottom))',
+          right: 'calc(1rem + var(--safe-right))',
+        }}
         onClick={() => setShowUpcoming(true)}
         title="Upcoming (hidden) tasks"
         onDragOver={(e) => { e.preventDefault(); setUpcomingHover(true); }}
@@ -3107,7 +3111,11 @@ export default function App() {
       {/* Drag trash can */}
       {draggingTaskId && (
         <div
-          className="fixed bottom-4 left-4 z-50"
+          className="fixed z-50"
+          style={{
+            bottom: 'calc(1rem + var(--safe-bottom))',
+            left: 'calc(1rem + var(--safe-left))',
+          }}
           onDragOver={(e) => {
             e.preventDefault();
             setTrashHover(true);
@@ -3139,7 +3147,10 @@ export default function App() {
 
       {/* Undo Snackbar */}
       {undoTask && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-surface-muted border border-surface text-sm px-4 py-2 rounded-xl shadow-lg flex items-center gap-3">
+        <div
+          className="fixed left-1/2 -translate-x-1/2 bg-surface-muted border border-surface text-sm px-4 py-2 rounded-xl shadow-lg flex items-center gap-3"
+          style={{ bottom: 'calc(1rem + var(--safe-bottom))' }}
+        >
           Task deleted
           <button onClick={undoDelete} className="pressable px-3 py-1 rounded-lg bg-emerald-600 hover:bg-emerald-500">Undo</button>
         </div>
@@ -3504,7 +3515,7 @@ const DroppableColumn = React.forwardRef<HTMLDivElement, {
       ref={setRef}
       data-column-title={title}
       data-drop-over={isDragOver || undefined}
-      className={`board-column surface-panel w-[325px] shrink-0 p-2 ${scrollable ? 'flex h-[calc(100vh-15rem)] flex-col overflow-hidden' : 'min-h-[320px]'} ${isDragOver ? 'board-column--active' : ''} ${className ?? ''}`}
+      className={`board-column surface-panel w-[325px] shrink-0 p-2 ${scrollable ? 'flex h-[calc(var(--app-height,_100dvh)-15rem)] flex-col overflow-hidden' : 'min-h-[320px]'} ${isDragOver ? 'board-column--active' : ''} ${className ?? ''}`}
       // No touchAction lock so horizontal scrolling stays fluid
       {...props}
     >

--- a/taskify-pwa/src/context/ToastContext.tsx
+++ b/taskify-pwa/src/context/ToastContext.tsx
@@ -25,7 +25,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   return (
     <ToastContext.Provider value={{ show }}>
       {children}
-      <div className="pointer-events-none fixed left-1/2 top-3 z-[10000] -translate-x-1/2">
+      <div
+        className="pointer-events-none fixed left-1/2 z-[10000] -translate-x-1/2"
+        style={{ top: 'calc(0.75rem + var(--safe-top))' }}
+      >
         <div
           className={
             "transition-opacity duration-200 " + (visible ? "opacity-100" : "opacity-0")

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -10,6 +10,12 @@
   -webkit-text-size-adjust: 100%;
   color-scheme: dark;
 
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --app-height: 100dvh;
+
   --accent: #0a84ff;
   --accent-hover: #409cff;
   --accent-active: #0060df;
@@ -68,12 +74,20 @@ html.light {
 }
 
 html,
+body {
+  height: 100%;
+}
+
+html,
 body,
 #root {
-  height: 100%;
   margin: 0;
   padding: 0;
   overflow-x: hidden;
+}
+
+#root {
+  min-height: 100%;
 }
 
 body {
@@ -83,10 +97,16 @@ body {
   font-family: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   letter-spacing: -0.01em;
-  padding-top: env(safe-area-inset-top);
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
   transition: background-color 280ms ease;
+}
+
+.app-shell {
+  min-height: calc(var(--app-height, 100dvh) - var(--safe-top) - var(--safe-bottom));
+  padding-top: var(--safe-top);
+  padding-right: var(--safe-right);
+  padding-bottom: var(--safe-bottom);
+  padding-left: var(--safe-left);
+  box-sizing: border-box;
 }
 
 body::before {
@@ -886,6 +906,10 @@ html.light .board-column[data-drop-over="true"] {
   border: 1px solid var(--surface-border);
   box-shadow: var(--shadow-soft);
   padding: 1.25rem;
+  padding-top: calc(1.25rem + var(--safe-top));
+  padding-right: calc(1.25rem + var(--safe-right));
+  padding-bottom: calc(1.25rem + var(--safe-bottom));
+  padding-left: calc(1.25rem + var(--safe-left));
   max-height: 80%;
   overflow-y: auto;
 }
@@ -903,12 +927,15 @@ html.light .board-column[data-drop-over="true"] {
 }
 
 .drawer-panel {
-  width: min(24rem, 92vw);
-  height: 100vh;
+  width: min(24rem, calc(92vw - var(--safe-left) - var(--safe-right)));
+  height: calc(var(--app-height, 100dvh) - var(--safe-top) - var(--safe-bottom));
   background: rgba(17, 18, 24, 0.96);
   border-left: 1px solid var(--surface-border);
   box-shadow: var(--shadow-soft);
-  padding: 1rem 1.25rem;
+  padding-top: calc(1rem + var(--safe-top));
+  padding-right: calc(1.25rem + var(--safe-right));
+  padding-bottom: calc(1rem + var(--safe-bottom));
+  padding-left: calc(1.25rem + var(--safe-left));
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- add a viewport height fallback script so the PWA tracks the visible iOS viewport when extending under the status bar
- introduce safe-area CSS variables and an app shell wrapper that pads content away from the notch and home indicator
- offset fixed UI elements, sheets, and drawers with safe-area insets to keep them visible with the black-translucent status bar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf8ec76988324afde53224beefd7e