### PR TITLE
Adjust upcoming drawer position

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -3025,7 +3025,7 @@ export default function App() {
       {/* Floating Upcoming Drawer Button */}
       <button
         ref={upcomingButtonRef}
-        className={`fixed bottom-4 right-4 px-3 py-2 rounded-full bg-surface-muted border border-surface shadow-lg text-sm transition-transform ${upcomingHover ? 'scale-110' : ''}`}
+        className={`fixed bottom-20 right-4 px-3 py-2 rounded-full bg-surface-muted border border-surface shadow-lg text-sm transition-transform ${upcomingHover ? 'scale-110' : ''}`}
         onClick={() => setShowUpcoming(true)}
         title="Upcoming (hidden) tasks"
         onDragOver={(e) => { e.preventDefault(); setUpcomingHover(true); }}


### PR DESCRIPTION
## Summary
- raise the floating Upcoming drawer trigger by increasing its bottom offset to sit higher on the screen

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb02a4cc4883249d5b96e39f04fdde