### PR TITLE
Add board zoom toggle with magnifier control

### DIFF
--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -491,6 +491,15 @@ html.light .board-column[data-drop-over="true"] {
   background: linear-gradient(180deg, var(--accent-soft), rgba(255, 255, 255, 0.6));
 }
 
+.board-zoom-target {
+  transform-origin: top right;
+  transition: transform 220ms ease;
+}
+
+.board-zoom-target--out {
+  transform: scale(0.58);
+}
+
 /* ================= Task cards ================= */
 .task-card {
   position: relative;


### PR DESCRIPTION
## Summary
- add a floating magnifier control that toggles a zoomed-out board view above the Upcoming drawer
- introduce styling and state handling to scale board columns when zoomed out
- add a settings toggle and persisted flag to show or hide the magnifier control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb180210a48324a8c76e0a1f6bb9a0