### PR TITLE
Restore magnifier scale zoom with scroll clamping

### DIFF
--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -491,6 +491,16 @@ html.light .board-column[data-drop-over="true"] {
   background: linear-gradient(180deg, var(--accent-soft), rgba(255, 255, 255, 0.6));
 }
 
+.board-zoom-target {
+  transform-origin: top center;
+  transition: transform 220ms ease;
+  will-change: transform;
+}
+
+.board-zoom-target--out {
+  transform: scale(var(--board-zoom-scale, 0.78));
+}
+
 /* ================= Task cards ================= */
 .task-card {
   position: relative;


### PR DESCRIPTION
## Summary
- reintroduce the magnifier's scale-based zoom effect while parameterizing the scale factor for both week and list boards
- recenter the horizontal scroller based on scaled dimensions and clamp scroll bounds when zoomed out so toggling preserves the viewport and prevents empty space beyond the last column

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb180210a48324a8c76e0a1f6bb9a0