### PR TITLE
Adjust Taskify header position

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -2438,7 +2438,7 @@ export default function App() {
         <header className="relative space-y-3">
           <div ref={confettiRef} className="pointer-events-none absolute inset-x-0 -top-2 z-20 h-0" />
           <div className="flex flex-wrap items-end gap-3">
-            <div className="flex flex-col gap-1 justify-end -translate-y-[2px]">
+            <div className="flex flex-col gap-1 justify-end -translate-y-2">
               <h1 className="text-3xl font-semibold tracking-tight">
                 Taskify
               </h1>


### PR DESCRIPTION
## Summary
- increase the upward translation on the Taskify title container so the heading sits higher in the header layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb22a28c10832485cab161eb5a5038