### PR TITLE
Include lightning contacts in backup exports

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { finalizeEvent, getPublicKey, generateSecretKey, type EventTemplate, nip19, nip04 } from "nostr-tools";
 import { CashuWalletModal } from "./components/CashuWalletModal";
 import { useCashu } from "./context/CashuContext";
+import { LS_LIGHTNING_CONTACTS } from "./localStorageKeys";
 import { loadStore as loadProofStore, saveStore as saveProofStore, getActiveMint, setActiveMint } from "./wallet/storage";
 import { encryptToBoard, decryptFromBoard, boardTag } from "./boardCrypto";
 import { useToast } from "./context/ToastContext";
@@ -4779,6 +4780,7 @@ function SettingsModal({
       boards: JSON.parse(localStorage.getItem(LS_BOARDS) || "[]"),
       settings: JSON.parse(localStorage.getItem(LS_SETTINGS) || "{}"),
       defaultRelays: JSON.parse(localStorage.getItem(LS_NOSTR_RELAYS) || "[]"),
+      contacts: JSON.parse(localStorage.getItem(LS_LIGHTNING_CONTACTS) || "[]"),
       nostrSk: localStorage.getItem(LS_NOSTR_SK) || "",
       cashu: {
         proofs: loadProofStore(),
@@ -4804,6 +4806,7 @@ function SettingsModal({
         if (data.boards) localStorage.setItem(LS_BOARDS, JSON.stringify(data.boards));
         if (data.settings) localStorage.setItem(LS_SETTINGS, JSON.stringify(data.settings));
         if (data.defaultRelays) localStorage.setItem(LS_NOSTR_RELAYS, JSON.stringify(data.defaultRelays));
+        if (data.contacts) localStorage.setItem(LS_LIGHTNING_CONTACTS, JSON.stringify(data.contacts));
         if (data.nostrSk) localStorage.setItem(LS_NOSTR_SK, data.nostrSk);
         if (data.cashu?.proofs) saveProofStore(data.cashu.proofs);
         if (data.cashu) setActiveMint(data.cashu.activeMint || null);

--- a/taskify-pwa/src/components/CashuWalletModal.tsx
+++ b/taskify-pwa/src/components/CashuWalletModal.tsx
@@ -7,13 +7,13 @@ import { QRCodeCanvas } from "qrcode.react";
 import { useCashu } from "../context/CashuContext";
 import { useNwc } from "../context/NwcContext";
 import { loadStore } from "../wallet/storage";
+import { LS_LIGHTNING_CONTACTS } from "../localStorageKeys";
 import { ActionSheet } from "./ActionSheet";
 
 QrScannerLib.WORKER_PATH = qrScannerWorkerPath;
 type ScanResult = QrScannerLib.ScanResult;
 
 const LNURL_DECODE_LIMIT = 2048;
-const LS_LIGHTNING_CONTACTS = "cashu_contacts_v1";
 const SMALL_ICON_BUTTON_STYLE = { "--icon-size": "2rem" } as React.CSSProperties;
 
 type LightningContact = {

--- a/taskify-pwa/src/localStorageKeys.ts
+++ b/taskify-pwa/src/localStorageKeys.ts
@@ -1,0 +1,1 @@
+export const LS_LIGHTNING_CONTACTS = "cashu_contacts_v1";


### PR DESCRIPTION
## Summary
- add a shared constant for the lightning contacts localStorage key
- include lightning contacts when exporting and restoring Taskify backups

## Testing
- `npm run build` *(fails: Rollup cannot resolve the existing bech32 dependency during bundling)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8030a5c08324a6e3e3e2cbe18f1e