### PR TITLE
Adjust lightning contacts sheet height

### DIFF
--- a/taskify-pwa/src/components/CashuWalletModal.tsx
+++ b/taskify-pwa/src/components/CashuWalletModal.tsx
@@ -1656,7 +1656,7 @@ export function CashuWalletModal({ open, onClose }: { open: boolean; onClose: ()
             )}
           </div>
           {contactsOpen && (
-            <div className="flex max-h-[65vh] flex-col gap-3 bg-surface-muted border border-surface rounded-2xl p-3 text-xs">
+            <div className="flex max-h-[calc(100vh-9rem)] flex-col gap-3 bg-surface-muted border border-surface rounded-2xl p-3 text-xs">
               <div className="text-secondary text-[11px]">
                 {sortedContacts.length
                   ? "Select a contact to use their lightning address."

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -1011,7 +1011,8 @@ html.light .board-column[data-drop-over="true"] {
   border: 1px solid var(--surface-border);
   box-shadow: var(--shadow-soft);
   padding: 1.25rem;
-  max-height: 80%;
+  max-height: calc(100vh - 1.5rem);
+  max-height: calc(100vh - env(safe-area-inset-top) - 1.5rem);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- allow the action sheet to use additional viewport height while respecting the safe area inset
- expand the lightning contacts panel height so more entries are visible before scrolling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd80eb555483249ef4a222cf6a9cef