### PR TITLE
Enhance complete task button styling

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -3873,7 +3873,7 @@ function Card({
           onClick={handleCompleteClick}
           aria-label={task.completed ? 'Mark incomplete' : 'Complete task'}
           title={task.completed ? 'Mark incomplete' : 'Mark complete'}
-          className="icon-button pressable flex-shrink-0"
+          className="icon-button pressable flex-shrink-0 task-card__complete-button"
           style={iconSizeStyle}
           data-active={task.completed}
         >

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -669,6 +669,35 @@ html.light .task-card:hover {
   padding: 0.25rem;
 }
 
+.task-card__complete-button {
+  --icon-size: 1.75rem;
+  border-width: 2px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.task-card__complete-button:hover {
+  background: var(--accent-hover);
+  color: #fff;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.24),
+    0 8px 18px color-mix(in srgb, var(--accent) 48%, transparent);
+  transform: translateY(-1px);
+}
+
+.task-card__complete-button[data-active='true'] {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: var(--accent-glow);
+}
+
+.task-card__complete-button[data-active='true']:hover {
+  background: var(--accent);
+}
+
 .icon-button--danger:hover {
   color: #ff6aa0;
   border-color: rgba(255, 92, 143, 0.52);


### PR DESCRIPTION
## Summary
- add a dedicated class to the task completion control so it can be tuned independently
- refresh the button styling with a smaller footprint and higher contrast hover/active states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0179fd988324a8f09ebd60a8f9aa