### PR TITLE
Adjust task completion button styling

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -3756,7 +3756,7 @@ function Card({
   const titleRef = useRef<HTMLDivElement>(null);
   const [overBefore, setOverBefore] = useState(false);
   const [isStacked, setIsStacked] = useState(false);
-  const iconSizeStyle = useMemo(() => ({ '--icon-size': '2.2rem' } as React.CSSProperties), []);
+  const iconSizeStyle = useMemo(() => ({ '--icon-size': '1.85rem' } as React.CSSProperties), []);
   const visibleSubtasks = useMemo(() => (
     hideCompletedSubtasks
       ? (task.subtasks?.filter((st) => !st.completed) ?? [])

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -665,8 +665,18 @@ html.light .task-card:hover {
 }
 
 .task-card .icon-button {
-  --icon-size: 2.1rem;
-  padding: 0.25rem;
+  --icon-size: 1.85rem;
+  padding: 0.18rem;
+  border-width: 1.5px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.02));
+  color: var(--text-secondary);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 6px 12px rgba(6, 12, 34, 0.22);
+}
+
+.task-card .icon-button[data-active="true"] {
+  color: #fff;
 }
 
 .icon-button--danger:hover {


### PR DESCRIPTION
## Summary
- shrink the task completion icon to reduce its footprint while keeping padding comfortable
- refresh the task card icon button styling with a brighter gradient, stronger border, and subtle shadow for better visibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf043160008324b61c97a4132570f2