### PR TITLE
Add npub.cash lightning address support with auto-claim settings

### DIFF
--- a/taskify-pwa/public/sw.js
+++ b/taskify-pwa/public/sw.js
@@ -8,13 +8,21 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(
     caches.open(CACHE).then(async (cache) => {
       const cached = await cache.match(event.request);
-      const fetcher = fetch(event.request)
-        .then((resp) => {
-          if (resp.ok) cache.put(event.request, resp.clone());
-          return resp;
-        })
-        .catch(() => cached);
-      return cached || fetcher;
+      try {
+        const networkResponse = await fetch(event.request);
+        if (networkResponse && networkResponse.ok) {
+          try {
+            await cache.put(event.request, networkResponse.clone());
+          } catch (err) {
+            // Ignore cache put errors (e.g. opaque responses)
+            console.warn('SW cache put failed', err);
+          }
+        }
+        return networkResponse;
+      } catch (err) {
+        if (cached) return cached;
+        return new Response(null, { status: 504, statusText: 'Gateway Timeout' });
+      }
     }),
   );
 });

--- a/taskify-pwa/src/components/CashuWalletModal.tsx
+++ b/taskify-pwa/src/components/CashuWalletModal.tsx
@@ -8,6 +8,12 @@ import { useCashu } from "../context/CashuContext";
 import { useNwc } from "../context/NwcContext";
 import { loadStore } from "../wallet/storage";
 import { LS_LIGHTNING_CONTACTS } from "../localStorageKeys";
+import { LS_NOSTR_SK } from "../nostrKeys";
+import {
+  NpubCashError,
+  claimPendingEcashFromNpubCash,
+  deriveNpubCashIdentity,
+} from "../wallet/npubCash";
 import { ActionSheet } from "./ActionSheet";
 
 QrScannerLib.WORKER_PATH = qrScannerWorkerPath;
@@ -316,12 +322,16 @@ export function CashuWalletModal({
   walletConversionEnabled,
   walletPrimaryCurrency,
   setWalletPrimaryCurrency,
+  npubCashLightningAddressEnabled,
+  npubCashAutoClaim,
 }: {
   open: boolean;
   onClose: () => void;
   walletConversionEnabled: boolean;
   walletPrimaryCurrency: "sat" | "usd";
   setWalletPrimaryCurrency: (currency: "sat" | "usd") => void;
+  npubCashLightningAddressEnabled: boolean;
+  npubCashAutoClaim: boolean;
 }) {
   const { mintUrl, setMintUrl, balance, info, createMintInvoice, checkMintQuote, claimMint, receiveToken, createSendToken, payInvoice: payMintInvoice } = useCashu();
   const { status: nwcStatus, connection: nwcConnection, info: nwcInfo, lastError: nwcError, connect: connectNwc, disconnect: disconnectNwc, refreshInfo: refreshNwcInfo, getBalanceMsat: getNwcBalanceMsat, payInvoice: payWithNwc, makeInvoice: makeNwcInvoice } = useNwc();
@@ -343,7 +353,14 @@ export function CashuWalletModal({
     | { type: "lnurl"; data: string }
     | { type: "paymentRequest"; request: string };
   const [pendingScan, setPendingScan] = useState<PendingScan | null>(null);
-  const [receiveMode, setReceiveMode] = useState<null | "ecash" | "lightning" | "lnurlWithdraw" | "nwcFund">(null);
+  const [receiveMode, setReceiveMode] = useState<
+    | null
+    | "ecash"
+    | "lightning"
+    | "lnurlWithdraw"
+    | "nwcFund"
+    | "npubCashAddress"
+  >(null);
   const [sendMode, setSendMode] = useState<null | "ecash" | "lightning" | "paymentRequest" | "nwcWithdraw">(null);
 
   const [btcUsdPrice, setBtcUsdPrice] = useState<number | null>(null);
@@ -433,8 +450,14 @@ export function CashuWalletModal({
   });
   const [showHistory, setShowHistory] = useState(false);
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
+  const [npubCashIdentity, setNpubCashIdentity] = useState<{ npub: string; address: string } | null>(null);
+  const [npubCashIdentityError, setNpubCashIdentityError] = useState<string | null>(null);
+  const [npubCashClaimStatus, setNpubCashClaimStatus] = useState<"idle" | "checking" | "success" | "error">("idle");
+  const [npubCashClaimMessage, setNpubCashClaimMessage] = useState("");
   const recvRef = useRef<HTMLTextAreaElement | null>(null);
   const lnRef = useRef<HTMLTextAreaElement | null>(null);
+  const npubCashClaimAbortRef = useRef<AbortController | null>(null);
+  const npubCashClaimingRef = useRef(false);
   const normalizedLnInput = useMemo(() => lnInput.trim().replace(/^lightning:/i, "").trim(), [lnInput]);
   const isLnAddress = useMemo(() => /^[^@\s]+@[^@\s]+$/.test(normalizedLnInput), [normalizedLnInput]);
   const isLnurlInput = useMemo(() => /^lnurl[0-9a-z]+$/i.test(normalizedLnInput), [normalizedLnInput]);
@@ -632,9 +655,152 @@ export function CashuWalletModal({
     }
   }
 
+  const handleClaimNpubCash = useCallback(
+    async (options?: { auto?: boolean }) => {
+      if (!npubCashLightningAddressEnabled) return;
+      if (npubCashClaimingRef.current) return;
+      const auto = options?.auto === true;
+      const storedSk = localStorage.getItem(LS_NOSTR_SK) || "";
+      if (!storedSk) {
+        setNpubCashIdentity(null);
+        const message = "Add your Taskify Nostr key in Settings → Nostr to use npub.cash.";
+        setNpubCashIdentityError(message);
+        if (!auto) {
+          setNpubCashClaimStatus("error");
+          setNpubCashClaimMessage(message);
+        }
+        return;
+      }
+
+      let identity: ReturnType<typeof deriveNpubCashIdentity> | null = null;
+      try {
+        identity = deriveNpubCashIdentity(storedSk);
+        setNpubCashIdentity({ npub: identity.npub, address: identity.address });
+        setNpubCashIdentityError(null);
+      } catch (err: any) {
+        const message = err?.message || "Unable to derive npub.cash address.";
+        setNpubCashIdentity(null);
+        setNpubCashIdentityError(message);
+        if (!auto) {
+          setNpubCashClaimStatus("error");
+          setNpubCashClaimMessage(message);
+        }
+        return;
+      }
+
+      if (!mintUrl) {
+        if (!auto) {
+          setNpubCashClaimStatus("error");
+          setNpubCashClaimMessage("Select an active mint before claiming from npub.cash.");
+        }
+        return;
+      }
+
+      const controller = new AbortController();
+      npubCashClaimAbortRef.current = controller;
+      npubCashClaimingRef.current = true;
+      setNpubCashClaimStatus("checking");
+      setNpubCashClaimMessage("Checking npub.cash for pending tokens…");
+
+      try {
+        const result = await claimPendingEcashFromNpubCash(storedSk, { signal: controller.signal });
+        const tokens = Array.isArray(result.tokens) ? result.tokens : [];
+        if (!tokens.length) {
+          setNpubCashClaimStatus("idle");
+          setNpubCashClaimMessage("No pending eCash found.");
+          return;
+        }
+
+        let successCount = 0;
+        let lastError: string | null = null;
+        for (const token of tokens) {
+          try {
+            await receiveToken(token);
+            successCount += 1;
+          } catch (err: any) {
+            lastError = err?.message || String(err);
+          }
+        }
+
+        if (lastError) {
+          setNpubCashClaimStatus("error");
+          const prefix = successCount ? `Claimed ${successCount} token${successCount === 1 ? "" : "s"}, but ` : "";
+          setNpubCashClaimMessage(`${prefix}${lastError}`);
+        } else {
+          setNpubCashClaimStatus("success");
+          setNpubCashClaimMessage(`Claimed ${successCount} token${successCount === 1 ? "" : "s"} from npub.cash.`);
+          const detailParts = [`Address ${identity.address}`];
+          if (identity.npub) detailParts.push(`npub ${identity.npub}`);
+          setHistory((prev) => [
+            {
+              id: `npubcash-${Date.now()}`,
+              summary: `Claimed ${successCount} token${successCount === 1 ? "" : "s"} via npub.cash`,
+              detail: detailParts.join(" · "),
+            },
+            ...prev,
+          ]);
+        }
+      } catch (err: any) {
+        if (err?.name === "AbortError") return;
+        if (err instanceof NpubCashError && err.status === 504) {
+          const message = err.message || "npub.cash request timed out. Please try again later.";
+          setNpubCashClaimStatus(auto ? "idle" : "error");
+          setNpubCashClaimMessage(message);
+          return;
+        }
+        const message = err?.message || "Unable to claim eCash from npub.cash.";
+        setNpubCashClaimStatus("error");
+        setNpubCashClaimMessage(message);
+      } finally {
+        npubCashClaimingRef.current = false;
+        if (npubCashClaimAbortRef.current === controller) {
+          npubCashClaimAbortRef.current = null;
+        }
+      }
+    },
+    [mintUrl, npubCashLightningAddressEnabled, receiveToken, setHistory],
+  );
+
   useEffect(() => {
     localStorage.setItem("cashuHistory", JSON.stringify(history));
   }, [history]);
+
+  useEffect(() => {
+    if (!npubCashLightningAddressEnabled) {
+      setNpubCashIdentity(null);
+      setNpubCashIdentityError(null);
+      return;
+    }
+    const storedSk = localStorage.getItem(LS_NOSTR_SK) || "";
+    if (!storedSk) {
+      setNpubCashIdentity(null);
+      setNpubCashIdentityError("Add your Taskify Nostr key in Settings → Nostr to use npub.cash.");
+      return;
+    }
+    try {
+      const identity = deriveNpubCashIdentity(storedSk);
+      setNpubCashIdentity({ npub: identity.npub, address: identity.address });
+      setNpubCashIdentityError(null);
+    } catch (err: any) {
+      setNpubCashIdentity(null);
+      setNpubCashIdentityError(err?.message || "Unable to derive npub.cash address.");
+    }
+  }, [npubCashLightningAddressEnabled, open]);
+
+  useEffect(() => {
+    if (!open || !npubCashLightningAddressEnabled || !npubCashAutoClaim) return;
+    void handleClaimNpubCash({ auto: true });
+  }, [open, npubCashLightningAddressEnabled, npubCashAutoClaim, handleClaimNpubCash]);
+
+  useEffect(() => {
+    return () => {
+      if (npubCashClaimAbortRef.current) {
+        npubCashClaimAbortRef.current.abort();
+        npubCashClaimAbortRef.current = null;
+      }
+      npubCashClaimingRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!open) {
@@ -1669,6 +1835,15 @@ export function CashuWalletModal({
             <span>eCash token</span>
             <span className="text-tertiary">→</span>
           </button>
+          {npubCashLightningAddressEnabled && (
+            <button
+              className="ghost-button button-sm pressable w-full justify-between"
+              onClick={()=>setReceiveMode("npubCashAddress")}
+            >
+              <span>Lightning address (npub.cash)</span>
+              <span className="text-tertiary">→</span>
+            </button>
+          )}
           <button className="ghost-button button-sm pressable w-full justify-between" onClick={()=>setReceiveMode("lightning")}>
             <span>Lightning invoice</span>
             <span className="text-tertiary">→</span>
@@ -1700,6 +1875,61 @@ export function CashuWalletModal({
             <button className="accent-button button-sm pressable" onClick={handleReceive} disabled={!mintUrl || !recvTokenStr}>Redeem</button>
             {recvMsg && <span className="text-xs">{recvMsg}</span>}
           </div>
+        </div>
+      </ActionSheet>
+
+      <ActionSheet
+        open={receiveMode === "npubCashAddress"}
+        onClose={()=>{
+          setReceiveMode(null);
+          setShowReceiveOptions(false);
+        }}
+        title="npub.cash Lightning address"
+      >
+        <div className="wallet-section space-y-3">
+          {npubCashIdentity ? (
+            <>
+              <QrCodeCard
+                value={npubCashIdentity.address}
+                label="Lightning address"
+                copyLabel="Copy address"
+              />
+              <div className="text-xs text-secondary">
+                Share this address to receive Lightning payments that arrive as Cashu tokens.
+              </div>
+              <div className="text-xs text-secondary break-all">Nostr npub: {npubCashIdentity.npub}</div>
+              <div className="space-y-2">
+                <div className="text-sm font-medium">Claim pending eCash</div>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-secondary">
+                  <button
+                    className="accent-button button-sm pressable"
+                    onClick={() => { void handleClaimNpubCash(); }}
+                    disabled={npubCashClaimStatus === "checking"}
+                  >
+                    {npubCashClaimStatus === "checking" ? "Checking…" : "Claim now"}
+                  </button>
+                  {npubCashAutoClaim && (
+                    <span>Auto-claim runs when you open the wallet.</span>
+                  )}
+                </div>
+                {npubCashClaimMessage && (
+                  <div
+                    className={`text-xs ${
+                      npubCashClaimStatus === "error"
+                        ? "text-rose-500"
+                        : npubCashClaimStatus === "success"
+                          ? "text-emerald-500"
+                          : "text-secondary"
+                    }`}
+                  >
+                    {npubCashClaimMessage}
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="text-xs text-secondary">{npubCashIdentityError || "Add your Taskify Nostr key to enable npub.cash."}</div>
+          )}
         </div>
       </ActionSheet>
 

--- a/taskify-pwa/src/nostrKeys.ts
+++ b/taskify-pwa/src/nostrKeys.ts
@@ -1,0 +1,2 @@
+export const LS_NOSTR_RELAYS = "taskify_nostr_relays_v1";
+export const LS_NOSTR_SK = "taskify_nostr_sk_v1";

--- a/taskify-pwa/src/wallet/npubCash.ts
+++ b/taskify-pwa/src/wallet/npubCash.ts
@@ -1,0 +1,240 @@
+import { bytesToHex } from "@noble/hashes/utils";
+import { finalizeEvent, getPublicKey, nip19, type EventTemplate } from "nostr-tools";
+
+const NPUB_CASH_API_BASE = "https://api.npub.cash/api/v1";
+
+export class NpubCashError extends Error {
+  status?: number;
+  raw?: unknown;
+
+  constructor(message: string, options: { status?: number; raw?: unknown } = {}) {
+    super(message);
+    this.name = "NpubCashError";
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.status = options.status;
+    this.raw = options.raw;
+  }
+}
+
+export type NpubCashIdentity = {
+  secretKey: string;
+  pubkey: string;
+  npub: string;
+  address: string;
+};
+
+export type NpubCashClaimResult = {
+  tokens: string[];
+  status: number;
+  raw: unknown;
+};
+
+function encodeBase64(data: string): string {
+  if (typeof btoa === "function") {
+    const encoder = new TextEncoder();
+    const bytes = encoder.encode(data);
+    let binary = "";
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary);
+  }
+  const globalBuffer = (globalThis as { Buffer?: { from: (input: string, encoding: string) => { toString: (encoding: string) => string } } }).Buffer;
+  if (globalBuffer) {
+    return globalBuffer.from(data, "utf8").toString("base64");
+  }
+  throw new Error("Base64 encoding unavailable");
+}
+
+function normalizeSecretKey(secretKey: string): string {
+  const trimmed = secretKey.trim();
+  if (!trimmed) {
+    throw new Error("Missing Nostr secret key");
+  }
+  if (trimmed.startsWith("nsec")) {
+    try {
+      const decoded = nip19.decode(trimmed);
+      if (decoded.type !== "nsec" || !decoded.data) {
+        throw new Error("Invalid nsec key");
+      }
+      if (typeof decoded.data === "string") {
+        return decoded.data;
+      }
+      if (decoded.data instanceof Uint8Array) {
+        return bytesToHex(decoded.data);
+      }
+      if (Array.isArray(decoded.data)) {
+        return bytesToHex(Uint8Array.from(decoded.data));
+      }
+      throw new Error("Unsupported nsec payload");
+    } catch (err: any) {
+      throw new Error(err?.message || "Invalid nsec key");
+    }
+  }
+  if (!/^[0-9a-f]{64}$/i.test(trimmed)) {
+    throw new Error("Invalid Nostr secret key");
+  }
+  return trimmed.toLowerCase();
+}
+
+export function deriveNpubCashIdentity(secretKey: string): NpubCashIdentity {
+  const normalizedSecret = normalizeSecretKey(secretKey);
+  const pubkey = getPublicKey(normalizedSecret);
+  const npub = nip19.npubEncode(pubkey);
+  return {
+    secretKey: normalizedSecret,
+    pubkey,
+    npub,
+    address: `${npub}@npub.cash`,
+  };
+}
+
+function buildNip98AuthHeader(url: string, method: string, secretKeyHex: string, body?: string): string {
+  const normalizedMethod = method?.toUpperCase?.() || "GET";
+  const template: EventTemplate = {
+    kind: 27235,
+    created_at: Math.floor(Date.now() / 1000),
+    tags: [
+      ["u", url],
+      ["method", normalizedMethod],
+    ],
+    content: body ?? "",
+  };
+  const event = finalizeEvent(template, secretKeyHex);
+  const payload = JSON.stringify(event);
+  return `Nostr ${encodeBase64(payload)}`;
+}
+
+function normalizeTokens(data: unknown): string[] {
+  if (!data) return [];
+  if (typeof data === "string") {
+    const trimmed = data.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (Array.isArray(data)) {
+    const nested = data.flatMap((item) => normalizeTokens(item));
+    return nested.filter((token) => typeof token === "string" && token.trim().length > 0);
+  }
+  if (typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+    const collected: string[] = [];
+    const keysToProbe = ["token", "tokens", "ecash", "proofs", "result", "values"] as const;
+    for (const key of keysToProbe) {
+      if (key in obj) {
+        collected.push(...normalizeTokens(obj[key]));
+      }
+    }
+    return collected.filter((token) => typeof token === "string" && token.trim().length > 0);
+  }
+  return [];
+}
+
+function uniqueTokens(tokens: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const token of tokens) {
+    const trimmed = token.trim();
+    if (!trimmed) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+async function readResponseBody(res: Response): Promise<unknown> {
+  const contentType = res.headers?.get?.("content-type") || "";
+  if (contentType.includes("application/json")) {
+    try {
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+  try {
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+export async function claimPendingEcashFromNpubCash(
+  secretKey: string,
+  options: { signal?: AbortSignal; fetcher?: typeof fetch } = {},
+): Promise<NpubCashClaimResult> {
+  const identity = deriveNpubCashIdentity(secretKey);
+  const fetcher = options.fetcher ?? fetch;
+  const targets = [
+    `${NPUB_CASH_API_BASE}/ecash/${identity.npub}`,
+    `${NPUB_CASH_API_BASE}/ecash/${identity.pubkey}`,
+  ];
+
+  let lastNoTokenStatus: number | null = null;
+  let lastNoTokenRaw: unknown = null;
+  let lastError: Error | null = null;
+
+  for (const url of targets) {
+    try {
+      const res = await fetcher(url, {
+        method: "GET",
+        headers: {
+          Authorization: buildNip98AuthHeader(url, "GET", identity.secretKey),
+          Accept: "application/json,text/plain",
+        },
+        signal: options.signal,
+      });
+
+      if (res.status === 404 || res.status === 204) {
+        lastNoTokenStatus = res.status;
+        lastNoTokenRaw = null;
+        continue;
+      }
+
+      if (!res.ok) {
+        const raw = await readResponseBody(res);
+        const fallback = `npub.cash error ${res.status}`;
+        const message =
+          (typeof raw === "string" && raw.trim()) ||
+          (raw && typeof raw === "object" && "message" in raw && typeof (raw as any).message === "string"
+            ? (raw as any).message
+            : undefined) ||
+          (res.status === 504
+            ? "npub.cash request timed out. Please try again later."
+            : res.status === 502
+            ? "npub.cash is temporarily unavailable. Please try again soon."
+            : fallback);
+        lastError = new NpubCashError(message, { status: res.status, raw });
+        continue;
+      }
+
+      const raw = await readResponseBody(res);
+      const tokens = uniqueTokens(normalizeTokens(raw));
+      if (!tokens.length) {
+        lastNoTokenStatus = res.status;
+        lastNoTokenRaw = raw;
+        continue;
+      }
+
+      return {
+        tokens,
+        status: res.status,
+        raw,
+      };
+    } catch (err: any) {
+      if (err?.name === "AbortError") {
+        throw err;
+      }
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  if (lastNoTokenStatus != null) {
+    return {
+      tokens: [],
+      status: lastNoTokenStatus,
+      raw: lastNoTokenRaw,
+    };
+  }
+
+  throw (lastError ?? new Error("Unable to fetch npub.cash claims."));
+}


### PR DESCRIPTION
## Summary
- ensure the service worker always returns a response when network fetches fail
- add a gateway-timeout fallback so npub.cash claim requests no longer produce null responses
- handle npub.cash timeout responses gracefully so auto-claiming doesn’t surface raw 504 errors

## Testing
- npm test --prefix taskify-pwa

------
https://chatgpt.com/codex/tasks/task_e_68cf140832308324897808a28df6e2ae