### PR TITLE
Allow root element to span full width

### DIFF
--- a/taskify-pwa/src/App.css
+++ b/taskify-pwa/src/App.css
@@ -1,6 +1,6 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: 2rem;
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- allow the root container to use the full viewport width so droppable columns can reach the edge of the screen

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0c309b0cc83249f86484fa143e008