### PR TITLE
Adjust font size selector labels

### DIFF
--- a/taskify-pwa/src/App.tsx
+++ b/taskify-pwa/src/App.tsx
@@ -6264,11 +6264,11 @@ function SettingsModal({
           <div className="space-y-4">
             <div>
               <div className="text-sm font-medium mb-2">Font size</div>
-              <div className="flex flex-wrap gap-2">
-                <button className={pillButtonClass(settings.baseFontSize == null)} onClick={() => setSettings({ baseFontSize: null })}>System</button>
-                <button className={pillButtonClass(settings.baseFontSize === 14)} onClick={() => setSettings({ baseFontSize: 14 })}>Small</button>
-                <button className={pillButtonClass(settings.baseFontSize === 20)} onClick={() => setSettings({ baseFontSize: 20 })}>Large</button>
-                <button className={pillButtonClass(settings.baseFontSize === 22)} onClick={() => setSettings({ baseFontSize: 22 })}>X-Large</button>
+              <div className="flex flex-wrap gap-1">
+                <button className={`${pillButtonClass(settings.baseFontSize == null)} button-xs`} onClick={() => setSettings({ baseFontSize: null })}>System</button>
+                <button className={`${pillButtonClass(settings.baseFontSize === 14)} button-xs`} onClick={() => setSettings({ baseFontSize: 14 })}>Sm</button>
+                <button className={`${pillButtonClass(settings.baseFontSize === 20)} button-xs`} onClick={() => setSettings({ baseFontSize: 20 })}>Lg</button>
+                <button className={`${pillButtonClass(settings.baseFontSize === 22)} button-xs`} onClick={() => setSettings({ baseFontSize: 22 })}>X-Lg</button>
               </div>
               <div className="text-xs text-secondary mt-2">Scales the entire UI. Defaults to a compact size.</div>
             </div>

--- a/taskify-pwa/src/index.css
+++ b/taskify-pwa/src/index.css
@@ -690,6 +690,11 @@ html.light .task-card:hover {
   padding: 0.32rem 0.75rem;
 }
 
+.button-xs {
+  font-size: 0.68rem;
+  padding: 0.28rem 0.55rem;
+}
+
 .task-card:hover {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.06));
   border-color: rgba(255, 255, 255, 0.18);


### PR DESCRIPTION
## Summary
- rename the settings font size buttons to System, Sm, Lg, and X-Lg
- apply a compact button size and tighter spacing so the controls stay on a single row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6bf1c38308324a5ea415ff13123d8